### PR TITLE
네트워크 요청 형식을 정의하기 위한 `RequestProtocol`와 `RequestType` 타입을 정의합니다.

### DIFF
--- a/iOSScalableAppStructure/Core/Data/API/Request/RequestProtocol.swift
+++ b/iOSScalableAppStructure/Core/Data/API/Request/RequestProtocol.swift
@@ -1,0 +1,73 @@
+//
+//  RequestProtocol.swift
+//  iOSScalableAppStructure
+//
+//  Created by Geonhee on 2022/08/01.
+//
+
+import Foundation
+
+protocol RequestProtocol {
+  var path: String { get }
+  var headers: [String: String] { get }
+  var params: [String: Any] { get }
+  var urlParams: [String: String?] { get }
+  var addAuthorizationToken: Bool { get }
+  var requestType: RequestType { get }
+}
+
+extension RequestProtocol {
+  var host: String {
+    return ApiConstants.host
+  }
+
+  var addAuthorizationToken: Bool {
+    return true
+  }
+
+  var params: [String: Any] {
+    return [:]
+  }
+
+  var urlParams: [String: String?] {
+    return [:]
+  }
+
+  var headers: [String: String] {
+    return [:]
+  }
+
+  func createUrlRequest(authToken: String) throws -> URLRequest {
+    var components = URLComponents()
+    components.scheme = "https"
+    components.host = host
+    components.path = path
+
+    if urlParams.isNotEmpty {
+      components.queryItems = urlParams.map(URLQueryItem.init(name:value:))
+    }
+
+    guard let url = components.url else {
+      throw NetworkError.invalidUrl
+    }
+
+    var urlRequest = URLRequest(url: url)
+    urlRequest.httpMethod = requestType.rawValue
+
+    if headers.isNotEmpty {
+      urlRequest.allHTTPHeaderFields = headers
+    }
+
+    if addAuthorizationToken {
+      urlRequest.setValue(authToken, forHTTPHeaderField: "Authorization")
+    }
+
+    urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+    if params.isNotEmpty {
+      urlRequest.httpBody = try JSONSerialization.data(withJSONObject: params)
+    }
+
+    return urlRequest
+  }
+}

--- a/iOSScalableAppStructure/Core/Data/API/Request/RequestType.swift
+++ b/iOSScalableAppStructure/Core/Data/API/Request/RequestType.swift
@@ -1,0 +1,11 @@
+//
+//  RequestType.swift
+//  iOSScalableAppStructure
+//
+//  Created by Geonhee on 2022/08/01.
+//
+
+enum RequestType: String {
+  case get = "GET"
+  case post = "POST"
+}

--- a/iOSScalableAppStructure/Core/Utilities/Occupiable.swift
+++ b/iOSScalableAppStructure/Core/Utilities/Occupiable.swift
@@ -1,0 +1,20 @@
+//
+//  Occupiable.swift
+//  iOSScalableAppStructure
+//
+//  Created by Geonhee on 2022/08/01.
+//
+
+protocol Occupiable {
+  var isEmpty: Bool { get }
+  var isNotEmpty: Bool { get }
+}
+
+extension Occupiable {
+  var isNotEmpty: Bool {
+    return !isEmpty
+  }
+}
+
+extension Dictionary: Occupiable {}
+extension String: Occupiable {}


### PR DESCRIPTION
# 목표
- 네트워킹 요청에 필요한 내용을 정의하기 위해 프로토콜을 정의합니다. 
- 해당 프로토콜을 준수하는 타입은 `URLRequest` 인스턴스를 생성할 수 있도록 인스턴스 메서드를 지원합니다.

# 결과
- 요청 타입은 `RequestProtocol`을 채택하여 `path`, `headers`, `params`, `urlParams`, `addAuthorizationToken`, `requestType`을 정의하여 사용할 수 있도록 구성했습니다.
- `RequestProtocol`을 준수하는 타입은 `createUrlRequest(authToken:)` 메서드를 사용해 `URLRequest`를 생성할 수 있습니다.
