### PR TITLE
Network layer의 핵심 역할을 수행하는 `ApiManager`를 추가합니다.

### DIFF
--- a/iOSScalableAppStructure/Core/Data/API/Error/NetworkError.swift
+++ b/iOSScalableAppStructure/Core/Data/API/Error/NetworkError.swift
@@ -1,0 +1,22 @@
+//
+//  NetworkError.swift
+//  iOSScalableAppStructure
+//
+//  Created by Geonhee on 2022/08/01.
+//
+
+import Foundation
+
+enum NetworkError: LocalizedError {
+  case invalidServerResponse
+  case invalidUrl
+
+  var errorDescription: String? {
+    switch self {
+    case .invalidServerResponse:
+      return "The server returned an invalid response."
+    case .invalidUrl:
+      return "URL string is malformed."
+    }
+  }
+}

--- a/iOSScalableAppStructure/Core/Data/API/Network/ApiManager.swift
+++ b/iOSScalableAppStructure/Core/Data/API/Network/ApiManager.swift
@@ -1,0 +1,41 @@
+//
+//  ApiManager.swift
+//  iOSScalableAppStructure
+//
+//  Created by Geonhee on 2022/08/01.
+//
+
+import Foundation
+
+protocol ApiManagerProtocol {
+  func perform(
+    _ request: RequestProtocol,
+    authToken: String
+  ) async throws -> Data
+}
+
+final class ApiManager: ApiManagerProtocol {
+
+  private let urlSession: URLSession
+
+  init(
+    urlSession: URLSession = URLSession.shared
+  ) {
+    self.urlSession = urlSession
+  }
+
+  func perform(
+    _ request: RequestProtocol,
+    authToken: String = ""
+  ) async throws -> Data {
+    let (data, response) = try await urlSession.data(
+      for: request.createUrlRequest(authToken: authToken)
+    )
+
+    guard let httpResponse = response as? HTTPURLResponse,
+          httpResponse.statusCode == 200 else {
+      throw NetworkError.invalidServerResponse
+    }
+    return data
+  }
+}


### PR DESCRIPTION
# 목표
- `URLSession` 인스턴스를 사용하여 네트워킹을 수행하는 핵심 타입인 `ApiManager`를 정의합니다.
- `ApiManager`는 자신을 의존하는 타입으로부터 `RequestProtocol`을 전달받아 `URLRequest` 인스턴스로 변환하여 네트워킹을 요청합니다.
- HTTP 상태 코드가 200인 경우에만 네트워킹 성공으로 간주하며, 이외의 응답은 `invalidServerResponse` 에러를 발생시킵니다.
- 네트워킹 성공 시 `Data` 타입의 인스턴스를 반환합니다.

# 결과
타입을 목표와 같이 정의했습니다.