### PR TITLE
네트워크 Authentication 획득 기능을 추가합니다.

### DIFF
--- a/iOSScalableAppStructure/Core/Data/API/Model/ApiToken.swift
+++ b/iOSScalableAppStructure/Core/Data/API/Model/ApiToken.swift
@@ -1,0 +1,42 @@
+//
+//  ApiToken.swift
+//  iOSScalableAppStructure
+//
+//  Created by Geonhee on 2022/08/01.
+//
+
+import Foundation
+
+struct ApiToken {
+  let tokenType: String
+  let expiresIn: Int
+  let accessToken: String
+  private let requestedAt = Date()
+}
+
+
+// MARK: - Codable
+
+extension ApiToken: Codable {
+  enum CodingKeys: String, CodingKey {
+    case tokenType
+    case expiresIn
+    case accessToken
+  }
+}
+
+// MARK: - Helper properties
+
+extension ApiToken {
+  var expiresAt: Date {
+    return Calendar.current.date(
+      byAdding: .second,
+      value: expiresIn,
+      to: requestedAt
+    ) ?? Date()
+  }
+
+  var bearerAccessToken: String {
+    return "\(tokenType) \(accessToken))"
+  }
+}

--- a/iOSScalableAppStructure/Core/Data/API/Network/ApiManager.swift
+++ b/iOSScalableAppStructure/Core/Data/API/Network/ApiManager.swift
@@ -12,6 +12,7 @@ protocol ApiManagerProtocol {
     _ request: RequestProtocol,
     authToken: String
   ) async throws -> Data
+  func requestToken() async throws -> Data
 }
 
 final class ApiManager: ApiManagerProtocol {
@@ -37,5 +38,9 @@ final class ApiManager: ApiManagerProtocol {
       throw NetworkError.invalidServerResponse
     }
     return data
+  }
+
+  func requestToken() async throws -> Data {
+    return try await perform(AuthTokenRequest.auth)
   }
 }

--- a/iOSScalableAppStructure/Core/Data/API/Network/RequestManager.swift
+++ b/iOSScalableAppStructure/Core/Data/API/Network/RequestManager.swift
@@ -1,0 +1,39 @@
+//
+//  RequestManager.swift
+//  iOSScalableAppStructure
+//
+//  Created by Geonhee on 2022/08/01.
+//
+
+import Foundation
+
+protocol RequestManagerProtocol {
+  func perform<T: Decodable>(_ request: RequestProtocol) async throws -> T
+}
+
+final class RequestManager: RequestManagerProtocol {
+
+  let apiManager: ApiManagerProtocol
+  let parser: DataParserProtocol
+
+  init(
+    apiManager: ApiManagerProtocol = ApiManager(),
+    parser: DataParserProtocol = DataParser()
+  ) {
+    self.apiManager = apiManager
+    self.parser = parser
+  }
+
+  func perform<T: Decodable>(_ request: RequestProtocol) async throws -> T {
+    let authToken = try await requestAccessToken()
+    let data = try await apiManager.perform(request, authToken: authToken)
+    let decoded: T = try parser.parse(data: data)
+    return decoded
+  }
+
+  func requestAccessToken() async throws -> String {
+    let data = try await apiManager.requestToken()
+    let token: ApiToken = try parser.parse(data: data)
+    return token.bearerAccessToken
+  }
+}

--- a/iOSScalableAppStructure/Core/Data/API/Parser/DataParser.swift
+++ b/iOSScalableAppStructure/Core/Data/API/Parser/DataParser.swift
@@ -1,0 +1,27 @@
+//
+//  DataParser.swift
+//  iOSScalableAppStructure
+//
+//  Created by Geonhee on 2022/08/01.
+//
+
+import Foundation
+
+protocol DataParserProtocol {
+  func parse<T: Decodable>(data: Data) throws -> T
+}
+
+final class DataParser: DataParserProtocol {
+  private var jsonDecoder: JSONDecoder
+
+  init(
+    jsonDecoder: JSONDecoder = JSONDecoder()
+  ) {
+    self.jsonDecoder = jsonDecoder
+    self.jsonDecoder.keyDecodingStrategy = .convertFromSnakeCase
+  }
+
+  func parse<T: Decodable>(data: Data) throws -> T {
+    return try jsonDecoder.decode(T.self, from: data)
+  }
+}

--- a/iOSScalableAppStructure/Core/Data/API/Request/Auth/AuthTokenRequest.swift
+++ b/iOSScalableAppStructure/Core/Data/API/Request/Auth/AuthTokenRequest.swift
@@ -1,0 +1,39 @@
+//
+//  AuthTokenRequest.swift
+//  iOSScalableAppStructure
+//
+//  Created by Geonhee on 2022/08/01.
+//
+
+/**
+Request for getting an authentication token
+
+{
+"grant_type": "client_credentials",
+"client_id": "CLIENT-ID",
+"client_secret": "CLIENT-SECRET"
+}
+*/
+enum AuthTokenRequest: RequestProtocol {
+  case auth
+
+  var path: String {
+    return "/v2/oauth2/token"
+  }
+
+  var params: [String : Any] {
+    return [
+      "grant_type": ApiConstants.grantType,
+      "client_id": ApiConstants.clientId,
+      "client_secret": ApiConstants.clientSecret
+    ]
+  }
+
+  var addAuthorizationToken: Bool {
+    return false
+  }
+
+  var requestType: RequestType {
+    return .post
+  }
+}


### PR DESCRIPTION
# 목표
1. API Key와 Secret Key를 통해 Access Token을 발급받는 Authentication 요청을 생성하는 타입을 정의합니다.
2. Access Token 요청 기능을 수행하는 타입과 메서드를 추가합니다.
3. 서버에서 응답한 Data를 파싱하는 타입을 추가합니다.

# 결과
각 목표별 정의한 타입 또는 메서드는 아래와 같으며 상세 내용은 변경사항을 참조합니다.
1. `AuthTokenRequest`
2. `RequestManagerProtocol`, `RequestManager`, `requestAccessToken()`
3. `DataParserProtocol`, `DataParser`