### PR TITLE
Access Token을 기기에 저장하여 활용하는 기능을 추가합니다.

### DIFF
--- a/iOSScalableAppStructure/Core/Data/API/Token/AccessTokenManager.swift
+++ b/iOSScalableAppStructure/Core/Data/API/Token/AccessTokenManager.swift
@@ -1,0 +1,72 @@
+//
+//  AccessTokenManager.swift
+//  iOSScalableAppStructure
+//
+//  Created by Geonhee on 2022/08/01.
+//
+
+import Foundation
+
+protocol AccessTokenManagerProtocol {
+  func isTokenValid() -> Bool
+  func fetchToken() -> String
+  func refreshWith(apiToken: ApiToken) throws
+}
+
+final class AccessTokenManager {
+  private let userDefaults: UserDefaults
+  private var accessToken: String?
+  private var expiresAt = Date()
+
+  init(
+    userDefaults: UserDefaults = .standard
+  ) {
+    self.userDefaults = userDefaults
+    update()
+  }
+}
+
+// MARK: - Access Token Manager Protocol
+
+extension AccessTokenManager: AccessTokenManagerProtocol {
+
+  func isTokenValid() -> Bool {
+    update()
+    return accessToken != nil && expiresAt.compare(Date()) == .orderedDescending
+  }
+
+  func fetchToken() -> String {
+    return accessToken ?? ""
+  }
+
+  func refreshWith(apiToken: ApiToken) throws {
+    let expiresAt = apiToken.expiresAt
+    let token = apiToken.bearerAccessToken
+
+    save(token: apiToken)
+    self.expiresAt = expiresAt
+    self.accessToken = token
+  }
+}
+
+// MARK: - Token Expiration
+
+private extension AccessTokenManager {
+  func save(token: ApiToken) {
+    userDefaults.set(token.expiresAt.timeIntervalSince1970, forKey: AppUserDefaultsKeys.expiresAt)
+    userDefaults.set(token.bearerAccessToken, forKey: AppUserDefaultsKeys.bearerAccessToken)
+  }
+
+  func expirationDate() -> Date {
+    return Date(timeIntervalSince1970: userDefaults.double(forKey: AppUserDefaultsKeys.expiresAt))
+  }
+
+  func token() -> String? {
+    return userDefaults.string(forKey: AppUserDefaultsKeys.bearerAccessToken)
+  }
+
+  func update() {
+    accessToken = token()
+    expiresAt = expirationDate()
+  }
+}

--- a/iOSScalableAppStructure/Core/Utilities/AppUserDefaultsKeys.swift
+++ b/iOSScalableAppStructure/Core/Utilities/AppUserDefaultsKeys.swift
@@ -1,0 +1,11 @@
+//
+//  AppUserDefaultsKeys.swift
+//  iOSScalableAppStructure
+//
+//  Created by Geonhee on 2022/08/01.
+//
+
+enum AppUserDefaultsKeys {
+  static let expiresAt = "expiresAt"
+  static let bearerAccessToken = "bearerAccessToken"
+}


### PR DESCRIPTION
# Related PRs
- #11 

# Background
- 기존 네트워킹 로직은 요청을 수행할 때마다 Auth Token을 발급받아 사용하는 형식으로 구성되어 있었습니다. 이 방식을 기기에 정보를 저장하는 방식을 활용해 효율적으로 변경합니다. 

# Objectives
- 기기에서 Access Token을 저장하여 Token이 만료될 때까지 활용하다 만료 시 재발급 받는 형태로 로직을 수정합니다.

# Results
- Access Token이 유효 여부를 판단하고 이를 저장하거나 기기에서 불러오는 `AccessTokenManagerProtocol`과 이를 준수하는 `AccessTokenManager`를 정의했습니다.
- 모든 네트워크 요청 시 이용되는 `RequestManager`의 `perform(_:)` 메서드를 수행하면 가장 먼저 `requestAccessToken()` 메서드를 호출하며, 이 메서드가 `AccessTokenManager`를 통해 유효한 Access Token이 있으면 기기에 저장된 Access Token을 반환합니다.
- `AccessTokenManager`가 유효한 Access Token을 가지고 있지 않다면 `ApiManager`를 통해 새로운 Access Token을 요청합니다. 새로운 Access Token을 발급받으면 `AccessTokenManager`의 `refreshWith(apiToken:)` 메서드로 신규 발급받은 토큰을 전달하여 기기에 저장합니다.
