### PR TITLE
기기에 데이터 저장을 지원하는 `PersistenceController`와 `Domain model`과 `CoreData entity` 간 양방향 변환을 지원하는 `CoreDataPersistable` 타입을 추가합니다.

### DIFF
--- a/iOSScalableAppStructure.xcodeproj/project.pbxproj
+++ b/iOSScalableAppStructure.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		AA34D7922897F7D800D37F26 /* AccessTokenManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA34D7912897F7D800D37F26 /* AccessTokenManagerTests.swift */; };
 		AA34D7A228980F8B00D37F26 /* iOSScalableAppStructure.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = AA34D7A028980F8B00D37F26 /* iOSScalableAppStructure.xcdatamodeld */; };
+		AA34D7D92898D40A00D37F26 /* CoreDataPersistable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA34D7D82898D40A00D37F26 /* CoreDataPersistable.swift */; };
 		AAA228092895077F00081167 /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA228082895077F00081167 /* App.swift */; };
 		AAA2280B2895077F00081167 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA2280A2895077F00081167 /* ContentView.swift */; };
 		AAA2280D2895078000081167 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AAA2280C2895078000081167 /* Assets.xcassets */; };
@@ -69,6 +70,7 @@
 /* Begin PBXFileReference section */
 		AA34D7912897F7D800D37F26 /* AccessTokenManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessTokenManagerTests.swift; sourceTree = "<group>"; };
 		AA34D7A128980F8B00D37F26 /* iOSScalableAppStructure.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = iOSScalableAppStructure.xcdatamodel; sourceTree = "<group>"; };
+		AA34D7D82898D40A00D37F26 /* CoreDataPersistable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataPersistable.swift; sourceTree = "<group>"; };
 		AAA228052895077F00081167 /* iOSScalableAppStructure.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSScalableAppStructure.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AAA228082895077F00081167 /* App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App.swift; sourceTree = "<group>"; };
 		AAA2280A2895077F00081167 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -138,6 +140,7 @@
 		AA34D7A32898C72900D37F26 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				AA34D7D82898D40A00D37F26 /* CoreDataPersistable.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -563,6 +566,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AA34D7D92898D40A00D37F26 /* CoreDataPersistable.swift in Sources */,
 				AACE3DFC2896EC52005ACB10 /* AuthTokenRequest.swift in Sources */,
 				AACE3DCB2896D2F7005ACB10 /* Animal.swift in Sources */,
 				AAA228362896870200081167 /* SearchView.swift in Sources */,

--- a/iOSScalableAppStructure.xcodeproj/project.pbxproj
+++ b/iOSScalableAppStructure.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		AA34D7922897F7D800D37F26 /* AccessTokenManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA34D7912897F7D800D37F26 /* AccessTokenManagerTests.swift */; };
 		AA34D7A228980F8B00D37F26 /* iOSScalableAppStructure.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = AA34D7A028980F8B00D37F26 /* iOSScalableAppStructure.xcdatamodeld */; };
 		AA34D7D92898D40A00D37F26 /* CoreDataPersistable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA34D7D82898D40A00D37F26 /* CoreDataPersistable.swift */; };
+		AA34D7DB2898E36B00D37F26 /* Breed+CoreData.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA34D7DA2898E36B00D37F26 /* Breed+CoreData.swift */; };
 		AAA228092895077F00081167 /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA228082895077F00081167 /* App.swift */; };
 		AAA2280B2895077F00081167 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA2280A2895077F00081167 /* ContentView.swift */; };
 		AAA2280D2895078000081167 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AAA2280C2895078000081167 /* Assets.xcassets */; };
@@ -71,6 +72,7 @@
 		AA34D7912897F7D800D37F26 /* AccessTokenManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessTokenManagerTests.swift; sourceTree = "<group>"; };
 		AA34D7A128980F8B00D37F26 /* iOSScalableAppStructure.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = iOSScalableAppStructure.xcdatamodel; sourceTree = "<group>"; };
 		AA34D7D82898D40A00D37F26 /* CoreDataPersistable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataPersistable.swift; sourceTree = "<group>"; };
+		AA34D7DA2898E36B00D37F26 /* Breed+CoreData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Breed+CoreData.swift"; sourceTree = "<group>"; };
 		AAA228052895077F00081167 /* iOSScalableAppStructure.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSScalableAppStructure.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AAA228082895077F00081167 /* App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App.swift; sourceTree = "<group>"; };
 		AAA2280A2895077F00081167 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -141,6 +143,7 @@
 			isa = PBXGroup;
 			children = (
 				AA34D7D82898D40A00D37F26 /* CoreDataPersistable.swift */,
+				AA34D7DA2898E36B00D37F26 /* Breed+CoreData.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -597,6 +600,7 @@
 				AACE3DD72896D5BD005ACB10 /* VideoLink.swift in Sources */,
 				AA34D7A228980F8B00D37F26 /* iOSScalableAppStructure.xcdatamodeld in Sources */,
 				AAA22825289685DD00081167 /* Coat.swift in Sources */,
+				AA34D7DB2898E36B00D37F26 /* Breed+CoreData.swift in Sources */,
 				AACE3E042896F269005ACB10 /* AnimalsContainer.swift in Sources */,
 				AACE3DEE2896E56D005ACB10 /* Occupiable.swift in Sources */,
 				AACE3DF42896E8F0005ACB10 /* ApiManager.swift in Sources */,

--- a/iOSScalableAppStructure/Core/Data/CoreData/Extensions/Breed+CoreData.swift
+++ b/iOSScalableAppStructure/Core/Data/CoreData/Extensions/Breed+CoreData.swift
@@ -1,0 +1,23 @@
+//
+//  Breed+CoreData.swift
+//  iOSScalableAppStructure
+//
+//  Created by Geonhee on 2022/08/02.
+//
+
+import CoreData
+
+extension Breed: CoreDataPersistable {
+
+  typealias ManagedType = BreedEntity
+
+  var keyMap: [PartialKeyPath<Breed> : String] {
+    return [
+      \.primary: "primary",
+       \.secondary: "secondary",
+       \.mixed: "mixed",
+       \.unknown: "unknown",
+       \.id: "id"
+    ]
+  }
+}

--- a/iOSScalableAppStructure/Core/Data/CoreData/Extensions/CoreDataPersistable.swift
+++ b/iOSScalableAppStructure/Core/Data/CoreData/Extensions/CoreDataPersistable.swift
@@ -1,0 +1,106 @@
+//
+//  CoreDataPersistable.swift
+//  iOSScalableAppStructure
+//
+//  Created by Geonhee on 2022/08/02.
+//
+
+import CoreData
+
+protocol UuidIdentifiable: Identifiable {
+  var id: Int? { get set }
+}
+
+protocol CoreDataPersistable: UuidIdentifiable {
+
+  associatedtype ManagedType
+
+  init()
+  init(managedObject: ManagedType?)
+
+  var keyMap: [PartialKeyPath<Self>: String] { get }
+
+  mutating func toManagedObject(context: NSManagedObjectContext) -> ManagedType
+  func save(context: NSManagedObjectContext) throws
+}
+
+extension CoreDataPersistable where ManagedType: NSManagedObject {
+
+  init(managedObject: ManagedType?) {
+    self.init()
+    guard let managedObject = managedObject else { return }
+
+    for attribute in managedObject.entity.attributesByName {
+      let keyPath = keyMap
+        .first(where: { $0.value == attribute.key })?
+        .key
+      if let keyPath = keyPath {
+        let value = managedObject.value(forKey: attribute.key)
+        storeValue(value, toKeyPath: keyPath)
+      }
+    }
+  }
+
+  private mutating func storeValue(
+    _ value: Any?,
+    toKeyPath partial: AnyKeyPath
+  ) {
+    switch partial {
+    case let keyPath as WritableKeyPath<Self, URL?>:
+      self[keyPath: keyPath] = value as? URL
+    case let keyPath as WritableKeyPath<Self, Int?>:
+      self[keyPath: keyPath] = value as? Int
+    case let keyPath as WritableKeyPath<Self, String?>:
+      self[keyPath: keyPath] = value as? String
+    case let keyPath as WritableKeyPath<Self, Bool?>:
+      self[keyPath: keyPath] = value as? Bool
+    case let keyPath as WritableKeyPath<Self, Double?>:
+      self[keyPath: keyPath] = value as? Double
+    default:
+      return
+    }
+  }
+
+  mutating func toManagedObject(
+    context: NSManagedObjectContext = PersistenceController.shared.container.viewContext
+  ) -> ManagedType {
+    let persistedValue: ManagedType
+
+    if let id = self.id {
+      let fetchRequest = ManagedType.fetchRequest()
+      fetchRequest.predicate = NSPredicate(format: "id = %@", id as CVarArg)
+
+      if let results = try? context.fetch(fetchRequest),
+         let firstResult = results.first as? ManagedType {
+        persistedValue = firstResult
+      } else {
+        persistedValue = ManagedType(context: context)
+        self.id = persistedValue.value(forKey: "id") as? Int
+      }
+    } else {
+      persistedValue = ManagedType(context: context)
+      self.id = persistedValue.value(forKey: "id") as? Int
+    }
+    return setValuesFromMirror(persistedValue: persistedValue)
+  }
+
+  private func setValuesFromMirror(persistedValue: ManagedType) -> ManagedType {
+    let mirror = Mirror(reflecting: self)
+
+    for case let (label?, value) in mirror.children {
+      let mirroredValue = Mirror(reflecting: value)
+
+      if mirroredValue.displayStyle != .optional ||
+          mirroredValue.children.isNotEmpty {
+        persistedValue.setValue(value, forKey: label)
+      }
+    }
+    return persistedValue
+  }
+
+  func save(
+    context: NSManagedObjectContext = PersistenceController.shared.container.viewContext
+  ) throws {
+    try context.save()
+  }
+}

--- a/iOSScalableAppStructure/Core/Data/CoreData/Persistence.swift
+++ b/iOSScalableAppStructure/Core/Data/CoreData/Persistence.swift
@@ -5,4 +5,63 @@
 //  Created by Geonhee on 2022/07/31.
 //
 
-struct PersistenceController {}
+import CoreData
+
+struct PersistenceController {
+
+  static let shared = PersistenceController()
+
+  static var preview: PersistenceController = {
+    let result = PersistenceController(inMemory: true)
+    let viewContext = result.container.viewContext
+
+    for i in 0..<10 {
+      let newItem = Item(context: viewContext)
+      newItem.timestamp = Date()
+    }
+
+    do {
+      try viewContext.save()
+    } catch {
+      let nsError = error as NSError
+      fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
+    }
+    return result
+  }()
+
+  let container: NSPersistentContainer
+
+  init(inMemory: Bool = false) {
+    container = NSPersistentContainer(name: "iOSScalableAppStructure")
+
+    if inMemory {
+      container
+        .persistentStoreDescriptions
+        .first?
+        .url = URL(fileURLWithPath: "/dev/null")
+
+      container.loadPersistentStores { _, error in
+        if let error = error as NSError? {
+          fatalError("Unresolved error \(error), \(error.userInfo)")
+        }
+      }
+      container.viewContext.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
+      container.viewContext.automaticallyMergesChangesFromParent = true
+    }
+  }
+
+  static func save() {
+    let context = PersistenceController.shared.container.viewContext
+    guard context.hasChanges else { return }
+
+    do {
+      try context.save()
+    } catch {
+      fatalError("""
+        \(#file), \
+        \(#function), \
+        \(error.localizedDescription)
+      """)
+    }
+  }
+}

--- a/iOSScalableAppStructure/Core/Utilities/Occupiable.swift
+++ b/iOSScalableAppStructure/Core/Utilities/Occupiable.swift
@@ -16,5 +16,6 @@ extension Occupiable {
   }
 }
 
+extension AnyCollection: Occupiable {}
 extension Dictionary: Occupiable {}
 extension String: Occupiable {}


### PR DESCRIPTION
# 목표
- First party framework인 `CoreData` 프레임워크를 이용해 기기에 데이터 저장을 지원하는 `PersistenceController`를 추가합니다.
- Domain model과 CoreData entity 간 변환 작업에 발생하는 boilerplate code를 최대한 제거하기 위해 이를 지원하는 `CoreDataPersistable` 프로토콜을 정의하고 기본 구현을 추가합니다.

# 결과
리뷰를 참조합니다.