### PR TITLE
정의된 도메인 모델과 코어 엔티티 간 변환을 지원하는 인터페이스를 추가합니다.

### DIFF
--- a/iOSScalableAppStructure.xcodeproj/project.pbxproj
+++ b/iOSScalableAppStructure.xcodeproj/project.pbxproj
@@ -11,6 +11,16 @@
 		AA34D7A228980F8B00D37F26 /* iOSScalableAppStructure.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = AA34D7A028980F8B00D37F26 /* iOSScalableAppStructure.xcdatamodeld */; };
 		AA34D7D92898D40A00D37F26 /* CoreDataPersistable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA34D7D82898D40A00D37F26 /* CoreDataPersistable.swift */; };
 		AA34D7DB2898E36B00D37F26 /* Breed+CoreData.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA34D7DA2898E36B00D37F26 /* Breed+CoreData.swift */; };
+		AA34D7DD2898F19000D37F26 /* Address+CoreData.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA34D7DC2898F19000D37F26 /* Address+CoreData.swift */; };
+		AA34D7DF2898F20600D37F26 /* Animal+CoreData.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA34D7DE2898F20600D37F26 /* Animal+CoreData.swift */; };
+		AA34D7E12898FB8F00D37F26 /* AnimalAttributes+CoreData.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA34D7E02898FB8F00D37F26 /* AnimalAttributes+CoreData.swift */; };
+		AA34D7E32898FBEA00D37F26 /* AnimalEnvironment+CoreData.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA34D7E22898FBEA00D37F26 /* AnimalEnvironment+CoreData.swift */; };
+		AA34D7E52898FC2D00D37F26 /* ApiColors+CoreData.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA34D7E42898FC2D00D37F26 /* ApiColors+CoreData.swift */; };
+		AA34D7E72898FCC700D37F26 /* Contact+CoreData.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA34D7E62898FCC700D37F26 /* Contact+CoreData.swift */; };
+		AA34D7E92898FDB000D37F26 /* Organization+CoreData.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA34D7E82898FDB000D37F26 /* Organization+CoreData.swift */; };
+		AA34D7EB2898FF1800D37F26 /* PhotoSizes+CoreData.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA34D7EA2898FF1800D37F26 /* PhotoSizes+CoreData.swift */; };
+		AA34D7ED2898FF7100D37F26 /* User+CoreData.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA34D7EC2898FF7100D37F26 /* User+CoreData.swift */; };
+		AA34D7EF2898FFB900D37F26 /* VideoLink+CoreData.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA34D7EE2898FFB900D37F26 /* VideoLink+CoreData.swift */; };
 		AAA228092895077F00081167 /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA228082895077F00081167 /* App.swift */; };
 		AAA2280B2895077F00081167 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA2280A2895077F00081167 /* ContentView.swift */; };
 		AAA2280D2895078000081167 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AAA2280C2895078000081167 /* Assets.xcassets */; };
@@ -73,6 +83,16 @@
 		AA34D7A128980F8B00D37F26 /* iOSScalableAppStructure.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = iOSScalableAppStructure.xcdatamodel; sourceTree = "<group>"; };
 		AA34D7D82898D40A00D37F26 /* CoreDataPersistable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataPersistable.swift; sourceTree = "<group>"; };
 		AA34D7DA2898E36B00D37F26 /* Breed+CoreData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Breed+CoreData.swift"; sourceTree = "<group>"; };
+		AA34D7DC2898F19000D37F26 /* Address+CoreData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Address+CoreData.swift"; sourceTree = "<group>"; };
+		AA34D7DE2898F20600D37F26 /* Animal+CoreData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Animal+CoreData.swift"; sourceTree = "<group>"; };
+		AA34D7E02898FB8F00D37F26 /* AnimalAttributes+CoreData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnimalAttributes+CoreData.swift"; sourceTree = "<group>"; };
+		AA34D7E22898FBEA00D37F26 /* AnimalEnvironment+CoreData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnimalEnvironment+CoreData.swift"; sourceTree = "<group>"; };
+		AA34D7E42898FC2D00D37F26 /* ApiColors+CoreData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ApiColors+CoreData.swift"; sourceTree = "<group>"; };
+		AA34D7E62898FCC700D37F26 /* Contact+CoreData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Contact+CoreData.swift"; sourceTree = "<group>"; };
+		AA34D7E82898FDB000D37F26 /* Organization+CoreData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Organization+CoreData.swift"; sourceTree = "<group>"; };
+		AA34D7EA2898FF1800D37F26 /* PhotoSizes+CoreData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PhotoSizes+CoreData.swift"; sourceTree = "<group>"; };
+		AA34D7EC2898FF7100D37F26 /* User+CoreData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "User+CoreData.swift"; sourceTree = "<group>"; };
+		AA34D7EE2898FFB900D37F26 /* VideoLink+CoreData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VideoLink+CoreData.swift"; sourceTree = "<group>"; };
 		AAA228052895077F00081167 /* iOSScalableAppStructure.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSScalableAppStructure.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AAA228082895077F00081167 /* App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App.swift; sourceTree = "<group>"; };
 		AAA2280A2895077F00081167 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -143,7 +163,17 @@
 			isa = PBXGroup;
 			children = (
 				AA34D7D82898D40A00D37F26 /* CoreDataPersistable.swift */,
+				AA34D7DC2898F19000D37F26 /* Address+CoreData.swift */,
+				AA34D7DE2898F20600D37F26 /* Animal+CoreData.swift */,
+				AA34D7E02898FB8F00D37F26 /* AnimalAttributes+CoreData.swift */,
+				AA34D7E22898FBEA00D37F26 /* AnimalEnvironment+CoreData.swift */,
+				AA34D7E42898FC2D00D37F26 /* ApiColors+CoreData.swift */,
 				AA34D7DA2898E36B00D37F26 /* Breed+CoreData.swift */,
+				AA34D7E62898FCC700D37F26 /* Contact+CoreData.swift */,
+				AA34D7E82898FDB000D37F26 /* Organization+CoreData.swift */,
+				AA34D7EA2898FF1800D37F26 /* PhotoSizes+CoreData.swift */,
+				AA34D7EC2898FF7100D37F26 /* User+CoreData.swift */,
+				AA34D7EE2898FFB900D37F26 /* VideoLink+CoreData.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -572,7 +602,9 @@
 				AA34D7D92898D40A00D37F26 /* CoreDataPersistable.swift in Sources */,
 				AACE3DFC2896EC52005ACB10 /* AuthTokenRequest.swift in Sources */,
 				AACE3DCB2896D2F7005ACB10 /* Animal.swift in Sources */,
+				AA34D7E52898FC2D00D37F26 /* ApiColors+CoreData.swift in Sources */,
 				AAA228362896870200081167 /* SearchView.swift in Sources */,
+				AA34D7E72898FCC700D37F26 /* Contact+CoreData.swift in Sources */,
 				AACE3DDD2896D64B005ACB10 /* ApiColors.swift in Sources */,
 				AACE3DFF2896ED85005ACB10 /* ApiToken.swift in Sources */,
 				AACE3DE92896E3D9005ACB10 /* RequestProtocol.swift in Sources */,
@@ -580,30 +612,38 @@
 				AAA2280B2895077F00081167 /* ContentView.swift in Sources */,
 				AACE3DD52896D599005ACB10 /* PhotoSizes.swift in Sources */,
 				AACE3E0B2896FB5E005ACB10 /* AccessTokenManager.swift in Sources */,
+				AA34D7E92898FDB000D37F26 /* Organization+CoreData.swift in Sources */,
 				AACE3DF12896E6D1005ACB10 /* NetworkError.swift in Sources */,
 				AACE3DD32896D576005ACB10 /* Breed.swift in Sources */,
 				AACE3DDF2896D673005ACB10 /* AdoptionStatus.swift in Sources */,
 				AACE3E0D2896FC91005ACB10 /* AppUserDefaultsKeys.swift in Sources */,
+				AA34D7EF2898FFB900D37F26 /* VideoLink+CoreData.swift in Sources */,
 				AACE3DE12896D899005ACB10 /* Pagination.swift in Sources */,
+				AA34D7DF2898F20600D37F26 /* Animal+CoreData.swift in Sources */,
 				AACE3DEB2896E455005ACB10 /* RequestType.swift in Sources */,
 				AAA2281E2896854100081167 /* Persistence.swift in Sources */,
 				AACE3DCD2896D4E4005ACB10 /* Size.swift in Sources */,
 				AACE3DF62896EA60005ACB10 /* RequestManager.swift in Sources */,
 				AACE3DD12896D539005ACB10 /* Age.swift in Sources */,
 				AAA228092895077F00081167 /* App.swift in Sources */,
+				AA34D7DD2898F19000D37F26 /* Address+CoreData.swift in Sources */,
 				AAA2281C2896659300081167 /* ApiConstants.swift in Sources */,
 				AACE3DD92896D5D7005ACB10 /* AnimalAttributes.swift in Sources */,
 				AAA22827289685F000081167 /* Organization.swift in Sources */,
 				AACE3DCF2896D510005ACB10 /* Gender.swift in Sources */,
 				AAA2282D2896865C00081167 /* AnimalDetailsView.swift in Sources */,
+				AA34D7E32898FBEA00D37F26 /* AnimalEnvironment+CoreData.swift in Sources */,
 				AACE3DDB2896D626005ACB10 /* AnimalEnvironment.swift in Sources */,
 				AACE3DD72896D5BD005ACB10 /* VideoLink.swift in Sources */,
+				AA34D7ED2898FF7100D37F26 /* User+CoreData.swift in Sources */,
 				AA34D7A228980F8B00D37F26 /* iOSScalableAppStructure.xcdatamodeld in Sources */,
 				AAA22825289685DD00081167 /* Coat.swift in Sources */,
+				AA34D7E12898FB8F00D37F26 /* AnimalAttributes+CoreData.swift in Sources */,
 				AA34D7DB2898E36B00D37F26 /* Breed+CoreData.swift in Sources */,
 				AACE3E042896F269005ACB10 /* AnimalsContainer.swift in Sources */,
 				AACE3DEE2896E56D005ACB10 /* Occupiable.swift in Sources */,
 				AACE3DF42896E8F0005ACB10 /* ApiManager.swift in Sources */,
+				AA34D7EB2898FF1800D37F26 /* PhotoSizes+CoreData.swift in Sources */,
 				AACE3DF92896EBA1005ACB10 /* DataParser.swift in Sources */,
 				AAA228322896869C00081167 /* AnimalsNearYouView.swift in Sources */,
 				AACE3DE32896DD5B005ACB10 /* AnimalsMock.swift in Sources */,

--- a/iOSScalableAppStructure/Core/Data/CoreData/Extensions/Address+CoreData.swift
+++ b/iOSScalableAppStructure/Core/Data/CoreData/Extensions/Address+CoreData.swift
@@ -1,0 +1,23 @@
+//
+//  Address+CoreData.swift
+//  iOSScalableAppStructure
+//
+//  Created by Geonhee on 2022/08/02.
+//
+
+extension Address: CoreDataPersistable {
+
+  typealias ManagedType = AddressEntity
+
+  var keyMap: [PartialKeyPath<Address> : String] {
+    return [
+      \.address1: "address1",
+       \.address2: "address2",
+       \.city: "city",
+       \.state: "state",
+       \.postcode: "postcode",
+       \.country: "country",
+       \.id: "id"
+    ]
+  }
+}

--- a/iOSScalableAppStructure/Core/Data/CoreData/Extensions/Animal+CoreData.swift
+++ b/iOSScalableAppStructure/Core/Data/CoreData/Extensions/Animal+CoreData.swift
@@ -1,0 +1,188 @@
+//
+//  Animal+CoreData.swift
+//  iOSScalableAppStructure
+//
+//  Created by Geonhee on 2022/08/02.
+//
+
+import CoreData
+
+extension AnimalEntity {
+
+  var age: Age {
+    get {
+      guard let ageValue = ageValue else { return .unknown }
+      return Age(rawValue: ageValue) ?? .unknown
+    }
+    set {
+      self.ageValue = newValue.rawValue
+    }
+  }
+
+  var coat: Coat {
+    get {
+      guard let coatValue = coatValue else { return .unknown }
+      return Coat(rawValue: coatValue) ?? .unknown
+    }
+    set {
+      self.coatValue = newValue.rawValue
+    }
+  }
+
+  var gender: Gender {
+    get {
+      guard let genderValue = genderValue else { return .unknown }
+      return Gender(rawValue: genderValue) ?? .unknown
+    }
+    set {
+      self.genderValue = newValue.rawValue
+    }
+  }
+
+  var size: Size {
+    get {
+      guard let sizeValue = sizeValue else { return .unknown }
+      return Size(rawValue: sizeValue) ?? .unknown
+    }
+    set {
+      self.sizeValue = newValue.rawValue
+    }
+  }
+
+  var status: AdoptionStatus {
+    get {
+      guard let statusValue = statusValue else { return .unknown }
+      return AdoptionStatus(rawValue: statusValue) ?? .unknown
+    }
+    set {
+      self.statusValue = newValue.rawValue
+    }
+  }
+
+  var breed: String {
+    return breeds?.primary ?? breeds?.secondary ?? ""
+  }
+
+  var picture: URL? {
+    guard let photos = photos,
+          photos.allObjects.isNotEmpty else { return nil }
+    let photosArray = photos.allObjects as? [PhotoSizesEntity]
+    guard let photosArray = photosArray,
+          let firstPhoto = photosArray.first else { return nil }
+    return firstPhoto.medium ?? firstPhoto.full
+  }
+
+  var photoLink: URL? {
+    guard let phoneNumber = contact?.phone else { return nil }
+    let formattedPhoneNumber = phoneNumber.replacingOccurrences(of: "(", with: "")
+      .replacingOccurrences(of: ")", with: "")
+      .replacingOccurrences(of: "-", with: "")
+      .replacingOccurrences(of: " ", with: "")
+    return URL(string: "tel:\(formattedPhoneNumber)")
+  }
+
+  var emailLink: URL? {
+    guard let emailAddress = contact?.email else { return nil }
+    return URL(string: "mailto:\(emailAddress)")
+  }
+
+  var address: String {
+    guard let address = contact?.address else { return "No address" }
+    return [
+      address.address1,
+      address.address2,
+      address.city,
+      address.state,
+      address.postcode,
+      address.country
+    ]
+      .compactMap { $0 }
+      .joined(separator: ", ")
+  }
+
+  var animalSpecies: String {
+    return species ?? "None"
+  }
+}
+
+extension Animal: UuidIdentifiable {
+
+  init(managedObject: AnimalEntity) {
+    self.age = managedObject.age
+    self.coat = managedObject.coat
+    self.description = managedObject.desc
+    self.distance = managedObject.distance
+    self.gender = managedObject.gender
+    self.id = Int(managedObject.id)
+    self.name = managedObject.name ?? "No name"
+    self.organizationId = managedObject.organizationId
+    self.publishedAt = managedObject.publishedAt?.description
+    self.size = managedObject.size
+    self.species = managedObject.species
+    self.status = managedObject.status
+    self.tags = []
+    self.type = managedObject.type ?? "No type"
+    self.url = managedObject.url
+    self.attributes = AnimalAttributes(managedObject: managedObject.attributes)
+    self.colors = ApiColors(managedObject: managedObject.colors)
+    self.contact = Contact(managedObject: managedObject.contact)
+    self.environment = AnimalEnvironment(managedObject: managedObject.environment)
+    let pictures = managedObject.photos?.allObjects as? [PhotoSizesEntity]
+    self.photos = pictures?.map(PhotoSizes.init(managedObject:)) ?? []
+    let videos = managedObject.videos?.allObjects as? [VideoLinkEntity]
+    self.videos = videos?.map(VideoLink.init(managedObject:)) ?? []
+    self.breeds = Breed(managedObject: managedObject.breeds)
+  }
+
+  private func checkForExistingAnimal(
+    id: Int,
+    context: NSManagedObjectContext = PersistenceController.shared.container.viewContext
+  ) -> Bool {
+    let fetchRequest = AnimalEntity.fetchRequest()
+    fetchRequest.predicate = NSPredicate(format: "id = %d", id)
+
+    guard let fetchedResults = try? context.fetch(fetchRequest) else {
+      return false
+    }
+    return fetchedResults.isNotEmpty
+  }
+
+  mutating func toManagedObject(
+    context: NSManagedObjectContext = PersistenceController.shared.container.viewContext
+  ) {
+    guard let id = self.id else { return }
+    guard checkForExistingAnimal(id: id, context: context) == false else { return }
+
+    let persistedValue = AnimalEntity(context: context)
+    persistedValue.timestamp = Date()
+    persistedValue.age = self.age
+    persistedValue.coat = self.coat ?? .short
+    persistedValue.desc = self.description
+    persistedValue.distance = self.distance ?? 0
+    persistedValue.gender = self.gender
+    persistedValue.id = Int64(id)
+    persistedValue.name = self.name
+    persistedValue.organizationId = self.organizationId
+    persistedValue.publishedAt = self.publishedAt
+    persistedValue.size = self.size
+    persistedValue.species = self.species
+    persistedValue.status = self.status
+    persistedValue.type = self.type
+    persistedValue.url = self.url
+    persistedValue.attributes = self.attributes.toManagedObject(context: context)
+    persistedValue.colors = self.colors.toManagedObject(context: context)
+    persistedValue.contact = self.contact.toManagedObject(context: context)
+    persistedValue.environment = self.environment?.toManagedObject(context: context)
+    let convertedPhotos = self.photos.map { photo -> PhotoSizesEntity in
+      var mutablePhoto = photo
+      return mutablePhoto.toManagedObject(context: context)
+    }
+    persistedValue.addToPhotos(NSSet(array: convertedPhotos))
+    let convertedVideos = self.videos.map { video -> VideoLinkEntity in
+      var mutableVideo = video
+      return mutableVideo.toManagedObject(context: context)
+    }
+    persistedValue.addToVideos(NSSet(array: convertedVideos))
+    persistedValue.breeds = self.breeds.toManagedObject(context: context)
+  }
+}

--- a/iOSScalableAppStructure/Core/Data/CoreData/Extensions/AnimalAttributes+CoreData.swift
+++ b/iOSScalableAppStructure/Core/Data/CoreData/Extensions/AnimalAttributes+CoreData.swift
@@ -1,0 +1,22 @@
+//
+//  AnimalAttributes+CoreData.swift
+//  iOSScalableAppStructure
+//
+//  Created by Geonhee on 2022/08/02.
+//
+
+extension AnimalAttributes: CoreDataPersistable {
+
+  typealias ManagedType = AnimalAttributesEntity
+
+  var keyMap: [PartialKeyPath<AnimalAttributes> : String] {
+    return [
+      \.id: "id",
+       \.declawed: "declawed",
+       \.houseTrained: "houseTrained",
+       \.shotsCurrent: "shotsCurrent",
+       \.spayedNeutered: "spayedNeutered",
+       \.specialNeeds: "specialNeeds"
+    ]
+  }
+}

--- a/iOSScalableAppStructure/Core/Data/CoreData/Extensions/AnimalEnvironment+CoreData.swift
+++ b/iOSScalableAppStructure/Core/Data/CoreData/Extensions/AnimalEnvironment+CoreData.swift
@@ -1,0 +1,20 @@
+//
+//  AnimalEnvironment+CoreData.swift
+//  iOSScalableAppStructure
+//
+//  Created by Geonhee on 2022/08/02.
+//
+
+extension AnimalEnvironment: CoreDataPersistable {
+
+  typealias ManagedType = AnimalEnvironmentEntity
+
+  var keyMap: [PartialKeyPath<AnimalEnvironment> : String] {
+    return [
+      \.id: "id",
+       \.cats: "cats",
+       \.dogs: "dogs",
+       \.children: "children"
+    ]
+  }
+}

--- a/iOSScalableAppStructure/Core/Data/CoreData/Extensions/ApiColors+CoreData.swift
+++ b/iOSScalableAppStructure/Core/Data/CoreData/Extensions/ApiColors+CoreData.swift
@@ -1,0 +1,20 @@
+//
+//  ApiColors+CoreData.swift
+//  iOSScalableAppStructure
+//
+//  Created by Geonhee on 2022/08/02.
+//
+
+extension ApiColors: CoreDataPersistable {
+
+  typealias ManagedType = ApiColorsEntity
+
+  var keyMap: [PartialKeyPath<ApiColors> : String] {
+    return [
+      \.id: "id",
+       \.primary: "primary",
+       \.secondary: "secondary",
+       \.tertiary: "tertiary"
+    ]
+  }
+}

--- a/iOSScalableAppStructure/Core/Data/CoreData/Extensions/Contact+CoreData.swift
+++ b/iOSScalableAppStructure/Core/Data/CoreData/Extensions/Contact+CoreData.swift
@@ -1,0 +1,41 @@
+//
+//  Contact+CoreData.swift
+//  iOSScalableAppStructure
+//
+//  Created by Geonhee on 2022/08/02.
+//
+
+import CoreData
+
+extension Contact: CoreDataPersistable {
+
+  typealias ManagedType = ContactEntity
+
+  var keyMap: [PartialKeyPath<Contact> : String] {
+    return [
+      \.id: "id",
+       \.address: "address",
+       \.phone: "phone",
+       \.email: "email"
+    ]
+  }
+
+  init(managedObject: ContactEntity?) {
+    guard let managedObject = managedObject else { return }
+    self.id = Int(managedObject.id)
+    self.email = managedObject.email
+    self.phone = managedObject.phone
+    self.address = Address(managedObject: managedObject.address)
+  }
+
+  func toManagedObject(context: NSManagedObjectContext) -> ContactEntity {
+    let persistedValue = ContactEntity(context: context)
+    persistedValue.email = self.email
+    persistedValue.phone = self.phone
+
+    if var address = self.address {
+      persistedValue.address = address.toManagedObject(context: context)
+    }
+    return persistedValue
+  }
+}

--- a/iOSScalableAppStructure/Core/Data/CoreData/Extensions/Organization+CoreData.swift
+++ b/iOSScalableAppStructure/Core/Data/CoreData/Extensions/Organization+CoreData.swift
@@ -1,0 +1,39 @@
+//
+//  Organization+CoreData.swift
+//  iOSScalableAppStructure
+//
+//  Created by Geonhee on 2022/08/02.
+//
+
+import CoreData
+
+extension Organization: CoreDataPersistable {
+
+  typealias ManagedType = OrganizationEntity
+
+  var keyMap: [PartialKeyPath<Organization> : String] {
+    return [
+      \.id: "id",
+       \.contact: "contact",
+       \.distance: "distance"
+    ]
+  }
+
+  init(managedObject: OrganizationEntity?) {
+    guard let managedObject = managedObject else { return }
+    self.id = Int(managedObject.id)
+    self.distance = managedObject.distance
+    guard let contact = managedObject.contact else { return }
+    self.contact = Contact(managedObject: contact)
+  }
+
+  func toManagedObject(context: NSManagedObjectContext) -> OrganizationEntity {
+    let persistedValue = OrganizationEntity(context: context)
+    persistedValue.distance = self.distance ?? 0
+
+    if let contact = self.contact {
+      persistedValue.contact = contact.toManagedObject(context: context)
+    }
+    return persistedValue
+  }
+}

--- a/iOSScalableAppStructure/Core/Data/CoreData/Extensions/PhotoSizes+CoreData.swift
+++ b/iOSScalableAppStructure/Core/Data/CoreData/Extensions/PhotoSizes+CoreData.swift
@@ -1,0 +1,21 @@
+//
+//  PhotoSizes+CoreData.swift
+//  iOSScalableAppStructure
+//
+//  Created by Geonhee on 2022/08/02.
+//
+
+extension PhotoSizes: CoreDataPersistable {
+
+  typealias ManagedType = PhotoSizesEntity
+
+  var keyMap: [PartialKeyPath<PhotoSizes> : String] {
+    return [
+      \.id: "id",
+       \.small: "small",
+       \.medium: "medium",
+       \.large: "large",
+       \.full: "full",
+    ]
+  }
+}

--- a/iOSScalableAppStructure/Core/Data/CoreData/Extensions/User+CoreData.swift
+++ b/iOSScalableAppStructure/Core/Data/CoreData/Extensions/User+CoreData.swift
@@ -1,0 +1,20 @@
+//
+//  User+CoreData.swift
+//  iOSScalableAppStructure
+//
+//  Created by Geonhee on 2022/08/02.
+//
+
+extension User: CoreDataPersistable {
+
+  typealias ManagedType = UserEntity
+
+  var keyMap: [PartialKeyPath<User> : String] {
+    return [
+      \.id: "id",
+       \.name: "name",
+       \.password: "password",
+       \.extra: "extra"
+    ]
+  }
+}

--- a/iOSScalableAppStructure/Core/Data/CoreData/Extensions/VideoLink+CoreData.swift
+++ b/iOSScalableAppStructure/Core/Data/CoreData/Extensions/VideoLink+CoreData.swift
@@ -1,0 +1,18 @@
+//
+//  VideoLink+CoreData.swift
+//  iOSScalableAppStructure
+//
+//  Created by Geonhee on 2022/08/02.
+//
+
+extension VideoLink: CoreDataPersistable {
+
+  typealias ManagedType = VideoLinkEntity
+
+  var keyMap: [PartialKeyPath<VideoLink> : String] {
+    return [
+      \.id: "id",
+       \.embedded: "embedded"
+    ]
+  }
+}

--- a/iOSScalableAppStructure/Core/Utilities/Occupiable.swift
+++ b/iOSScalableAppStructure/Core/Utilities/Occupiable.swift
@@ -18,4 +18,5 @@ extension Occupiable {
 
 extension AnyCollection: Occupiable {}
 extension Dictionary: Occupiable {}
+extension Array: Occupiable {}
 extension String: Occupiable {}


### PR DESCRIPTION
# Related PRs
- #18 

# Background
앱의 비즈니스 로직에 활용되는 도메인 모델과 기기 저장을 위해 사용되는 코어 데이터 엔티티는 작업한 내용을 기기에 저장하거나 불러오는 등 필요에 따라 매핑되는 상대 타입의 인스턴스로 변환되는 경우가 잦습니다. 이를 위해 정의된 도메인 모델과 코어 엔티티 간 변환을 지원하는 인터페이스를 추가합니다.

# Objectives
1. 정의된 도메인 모델과 코어 엔티티 간 변환을 지원하는 인터페이스를 추가합니다.

# Results
변경사항을 참조합니다.
