### PR TITLE
콜론 전후의 공백 코드 컨벤션을 통일합니다.

### DIFF
--- a/iOSScalableAppStructure/Core/Data/API/Request/Animals/AnimalsRequest.swift
+++ b/iOSScalableAppStructure/Core/Data/API/Request/Animals/AnimalsRequest.swift
@@ -21,7 +21,7 @@ enum AnimalsRequest: RequestProtocol {
     return "/v2/animals"
   }
 
-  var urlParams: [String : String?] {
+  var urlParams: [String: String?] {
     switch self {
     case let .getAnimalsWith(page, latitude, longitude):
       var params = ["page": String(page)]

--- a/iOSScalableAppStructure/Core/Data/API/Request/Auth/AuthTokenRequest.swift
+++ b/iOSScalableAppStructure/Core/Data/API/Request/Auth/AuthTokenRequest.swift
@@ -21,7 +21,7 @@ enum AuthTokenRequest: RequestProtocol {
     return "/v2/oauth2/token"
   }
 
-  var params: [String : Any] {
+  var params: [String: Any] {
     return [
       "grant_type": ApiConstants.grantType,
       "client_id": ApiConstants.clientId,

--- a/iOSScalableAppStructure/Core/Data/CoreData/Extensions/Address+CoreData.swift
+++ b/iOSScalableAppStructure/Core/Data/CoreData/Extensions/Address+CoreData.swift
@@ -9,7 +9,7 @@ extension Address: CoreDataPersistable {
 
   typealias ManagedType = AddressEntity
 
-  var keyMap: [PartialKeyPath<Address> : String] {
+  var keyMap: [PartialKeyPath<Address>: String] {
     return [
       \.address1: "address1",
        \.address2: "address2",

--- a/iOSScalableAppStructure/Core/Data/CoreData/Extensions/AnimalAttributes+CoreData.swift
+++ b/iOSScalableAppStructure/Core/Data/CoreData/Extensions/AnimalAttributes+CoreData.swift
@@ -9,7 +9,7 @@ extension AnimalAttributes: CoreDataPersistable {
 
   typealias ManagedType = AnimalAttributesEntity
 
-  var keyMap: [PartialKeyPath<AnimalAttributes> : String] {
+  var keyMap: [PartialKeyPath<AnimalAttributes>: String] {
     return [
       \.id: "id",
        \.declawed: "declawed",

--- a/iOSScalableAppStructure/Core/Data/CoreData/Extensions/AnimalEnvironment+CoreData.swift
+++ b/iOSScalableAppStructure/Core/Data/CoreData/Extensions/AnimalEnvironment+CoreData.swift
@@ -9,7 +9,7 @@ extension AnimalEnvironment: CoreDataPersistable {
 
   typealias ManagedType = AnimalEnvironmentEntity
 
-  var keyMap: [PartialKeyPath<AnimalEnvironment> : String] {
+  var keyMap: [PartialKeyPath<AnimalEnvironment>: String] {
     return [
       \.id: "id",
        \.cats: "cats",

--- a/iOSScalableAppStructure/Core/Data/CoreData/Extensions/ApiColors+CoreData.swift
+++ b/iOSScalableAppStructure/Core/Data/CoreData/Extensions/ApiColors+CoreData.swift
@@ -9,7 +9,7 @@ extension ApiColors: CoreDataPersistable {
 
   typealias ManagedType = ApiColorsEntity
 
-  var keyMap: [PartialKeyPath<ApiColors> : String] {
+  var keyMap: [PartialKeyPath<ApiColors>: String] {
     return [
       \.id: "id",
        \.primary: "primary",

--- a/iOSScalableAppStructure/Core/Data/CoreData/Extensions/Breed+CoreData.swift
+++ b/iOSScalableAppStructure/Core/Data/CoreData/Extensions/Breed+CoreData.swift
@@ -11,7 +11,7 @@ extension Breed: CoreDataPersistable {
 
   typealias ManagedType = BreedEntity
 
-  var keyMap: [PartialKeyPath<Breed> : String] {
+  var keyMap: [PartialKeyPath<Breed>: String] {
     return [
       \.primary: "primary",
        \.secondary: "secondary",

--- a/iOSScalableAppStructure/Core/Data/CoreData/Extensions/Contact+CoreData.swift
+++ b/iOSScalableAppStructure/Core/Data/CoreData/Extensions/Contact+CoreData.swift
@@ -11,7 +11,7 @@ extension Contact: CoreDataPersistable {
 
   typealias ManagedType = ContactEntity
 
-  var keyMap: [PartialKeyPath<Contact> : String] {
+  var keyMap: [PartialKeyPath<Contact>: String] {
     return [
       \.id: "id",
        \.address: "address",

--- a/iOSScalableAppStructure/Core/Data/CoreData/Extensions/Organization+CoreData.swift
+++ b/iOSScalableAppStructure/Core/Data/CoreData/Extensions/Organization+CoreData.swift
@@ -11,7 +11,7 @@ extension Organization: CoreDataPersistable {
 
   typealias ManagedType = OrganizationEntity
 
-  var keyMap: [PartialKeyPath<Organization> : String] {
+  var keyMap: [PartialKeyPath<Organization>: String] {
     return [
       \.id: "id",
        \.contact: "contact",

--- a/iOSScalableAppStructure/Core/Data/CoreData/Extensions/PhotoSizes+CoreData.swift
+++ b/iOSScalableAppStructure/Core/Data/CoreData/Extensions/PhotoSizes+CoreData.swift
@@ -9,7 +9,7 @@ extension PhotoSizes: CoreDataPersistable {
 
   typealias ManagedType = PhotoSizesEntity
 
-  var keyMap: [PartialKeyPath<PhotoSizes> : String] {
+  var keyMap: [PartialKeyPath<PhotoSizes>: String] {
     return [
       \.id: "id",
        \.small: "small",

--- a/iOSScalableAppStructure/Core/Data/CoreData/Extensions/User+CoreData.swift
+++ b/iOSScalableAppStructure/Core/Data/CoreData/Extensions/User+CoreData.swift
@@ -9,7 +9,7 @@ extension User: CoreDataPersistable {
 
   typealias ManagedType = UserEntity
 
-  var keyMap: [PartialKeyPath<User> : String] {
+  var keyMap: [PartialKeyPath<User>: String] {
     return [
       \.id: "id",
        \.name: "name",

--- a/iOSScalableAppStructure/Core/Data/CoreData/Extensions/VideoLink+CoreData.swift
+++ b/iOSScalableAppStructure/Core/Data/CoreData/Extensions/VideoLink+CoreData.swift
@@ -9,7 +9,7 @@ extension VideoLink: CoreDataPersistable {
 
   typealias ManagedType = VideoLinkEntity
 
-  var keyMap: [PartialKeyPath<VideoLink> : String] {
+  var keyMap: [PartialKeyPath<VideoLink>: String] {
     return [
       \.id: "id",
        \.embedded: "embedded"


### PR DESCRIPTION
# Background
Protocol에 정의된 Dictionary 프로퍼티를 Code completion을 통해 입력하는 경우 콜론 전후에 공백이 있는 것을 확인했습니다.

# Objectives
- Swift에서 딕셔너리 타입을 작성할 때 콜론 앞은 공백이 없고 뒤는 공백이 있는 형식을 일반적으로 사용합니다. 아래와 같이 변경합니다.

```swift
let someDictionary: [String: Int] = [
  "ABC": 1,
  "DEF": 2,
  ...
]
``` 

# Results
변경사항을 참조합니다.