### PR TITLE
CI 조건에서 main branch push를 제거합니다.

### DIFF
--- a/.github/workflows/test_every_PR_for_main.yml
+++ b/.github/workflows/test_every_PR_for_main.yml
@@ -1,8 +1,6 @@
-name: test-every-push-and-PR
+name: test-every-PR-for-main
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 


### PR DESCRIPTION
# Related PRs
- #21
- #22 
- #23

# Background & Objectives
main branch에 PR하면 CI가 작동하도록 설정되어 있으므로 main branch에 push를 하거나 merge를 하는 경우에는 CI 대상에서 제외합니다. main branch에서 바로 push를 하는 경우는 없습니다.

# Results
변경사항을 참조합니다.