### PR TITLE
`AnimalsNearYouView` 화면의 `animals`에 `SectionedFetchRequest`을 적용하여 동물 목록을 섹션으로 구분합니다.

### DIFF
--- a/iOSScalableAppStructure.xcodeproj/project.pbxproj
+++ b/iOSScalableAppStructure.xcodeproj/project.pbxproj
@@ -61,7 +61,7 @@
 		AACE3DFF2896ED85005ACB10 /* ApiToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACE3DFE2896ED85005ACB10 /* ApiToken.swift */; };
 		AACE3E022896F0F7005ACB10 /* AnimalsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACE3E012896F0F7005ACB10 /* AnimalsRequest.swift */; };
 		AACE3E042896F269005ACB10 /* AnimalsContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACE3E032896F269005ACB10 /* AnimalsContainer.swift */; };
-		AACE3E082896F46A005ACB10 /* AnimalRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACE3E072896F46A005ACB10 /* AnimalRowView.swift */; };
+		AACE3E082896F46A005ACB10 /* AnimalRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACE3E072896F46A005ACB10 /* AnimalRow.swift */; };
 		AACE3E0B2896FB5E005ACB10 /* AccessTokenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACE3E0A2896FB5E005ACB10 /* AccessTokenManager.swift */; };
 		AACE3E0D2896FC91005ACB10 /* AppUserDefaultsKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACE3E0C2896FC91005ACB10 /* AppUserDefaultsKeys.swift */; };
 		AACE3E142897D623005ACB10 /* ApiManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACE3E132897D623005ACB10 /* ApiManagerMock.swift */; };
@@ -136,7 +136,7 @@
 		AACE3DFE2896ED85005ACB10 /* ApiToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiToken.swift; sourceTree = "<group>"; };
 		AACE3E012896F0F7005ACB10 /* AnimalsRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimalsRequest.swift; sourceTree = "<group>"; };
 		AACE3E032896F269005ACB10 /* AnimalsContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimalsContainer.swift; sourceTree = "<group>"; };
-		AACE3E072896F46A005ACB10 /* AnimalRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimalRowView.swift; sourceTree = "<group>"; };
+		AACE3E072896F46A005ACB10 /* AnimalRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimalRow.swift; sourceTree = "<group>"; };
 		AACE3E0A2896FB5E005ACB10 /* AccessTokenManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessTokenManager.swift; sourceTree = "<group>"; };
 		AACE3E0C2896FC91005ACB10 /* AppUserDefaultsKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUserDefaultsKeys.swift; sourceTree = "<group>"; };
 		AACE3E132897D623005ACB10 /* ApiManagerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiManagerMock.swift; sourceTree = "<group>"; };
@@ -359,7 +359,7 @@
 		AAA2282F2896868A00081167 /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				AACE3E072896F46A005ACB10 /* AnimalRowView.swift */,
+				AACE3E072896F46A005ACB10 /* AnimalRow.swift */,
 				AAA228312896869C00081167 /* AnimalsNearYouView.swift */,
 			);
 			path = Views;
@@ -663,7 +663,7 @@
 				AAA228322896869C00081167 /* AnimalsNearYouView.swift in Sources */,
 				AACE3DE32896DD5B005ACB10 /* AnimalsMock.swift in Sources */,
 				AAA22829289685FC00081167 /* User.swift in Sources */,
-				AACE3E082896F46A005ACB10 /* AnimalRowView.swift in Sources */,
+				AACE3E082896F46A005ACB10 /* AnimalRow.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOSScalableAppStructure/AnimalsNearYou/Views/AnimalRow.swift
+++ b/iOSScalableAppStructure/AnimalsNearYou/Views/AnimalRow.swift
@@ -1,5 +1,5 @@
 //
-//  AnimalRowView.swift
+//  AnimalRow.swift
 //  iOSScalableAppStructure
 //
 //  Created by Geonhee on 2022/08/01.
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct AnimalRowView: View {
+struct AnimalRow: View {
 
   let animal: AnimalEntity
 
@@ -47,7 +47,7 @@ struct AnimalRowView: View {
 struct AnimalRow_Previews: PreviewProvider {
   static var previews: some View {
     if let animal = CoreDataHelper.testAnimalEntity() {
-      AnimalRowView(animal: animal)
+      AnimalRow(animal: animal)
     }
   }
 }

--- a/iOSScalableAppStructure/ContentView.swift
+++ b/iOSScalableAppStructure/ContentView.swift
@@ -8,9 +8,16 @@
 import SwiftUI
 
 struct ContentView: View {
+
+  private let managedObjectContext = PersistenceController.shared.container.viewContext
+
   var body: some View {
     TabView {
       AnimalsNearYouView()
+        .environment(
+          \.managedObjectContext,
+           managedObjectContext
+        )
         .tabItem {
           Label("Near you", systemImage: "location")
         }

--- a/iOSScalableAppStructure/Core/Data/CoreData/Extensions/Animal+CoreData.swift
+++ b/iOSScalableAppStructure/Core/Data/CoreData/Extensions/Animal+CoreData.swift
@@ -100,7 +100,7 @@ extension AnimalEntity {
       .joined(separator: ", ")
   }
 
-  var animalSpecies: String {
+  @objc var animalSpecies: String {
     return species ?? "None"
   }
 }


### PR DESCRIPTION
# Objectives
1. `AnimalsNearYouView`의 동물 리스트를 종 (`AnimalEntity` - `animalSpecies`) 단위로 구분하여 섹션으로 구성하여 표시합니다.
2. `PersistenceController`의 `shared` 인스턴스의 `viewContext`를 이용하여 기기에 저장된 동물들을 가져오되, iOS 15.0부터 도입된`@SectionedFetchRequest(sectionIdentifier:sortDescriptors:animation:)` property wrapper를 이용하여 섹션별로 구분된 데이터를 가져옵니다.

# Results
| | iPhone 13 Pro |
|--|--|
| gif | <img src="https://user-images.githubusercontent.com/69730931/182591540-006d2fa7-7a75-4523-bed1-7e70369043d1.gif" width="320"> |


