### PR TITLE
Persistent container가 `CloudKit`을 지원하도록 변경합니다.

### DIFF
--- a/iOSScalableAppStructure/Core/Data/CoreData/Persistence.swift
+++ b/iOSScalableAppStructure/Core/Data/CoreData/Persistence.swift
@@ -29,10 +29,10 @@ struct PersistenceController {
     return result
   }()
 
-  let container: NSPersistentContainer
+  let container: NSPersistentCloudKitContainer
 
   init(inMemory: Bool = false) {
-    container = NSPersistentContainer(name: "iOSScalableAppStructure")
+    container = NSPersistentCloudKitContainer(name: "iOSScalableAppStructure")
 
     if inMemory {
       container


### PR DESCRIPTION
# Background
사용자가 사용 중인 기기에 관계없이 동일한 Apple ID를 이용하고 있다면 기기에 저장된 내용을 공유할 수 있도록 iCloud 기능을 추가합니다.
실제로는 Apple Developer Program에 등록된 결제된 계정을 팀으로 등록하고, 타겟의 `Signing & Capabilities` 탭에서 `iCloud` capability를 활성화시켜야 기능을 사용할 수 있습니다.

# Objectives
1. `NSPersistentContainer`를 `NSPersistentCloudKitContainer` 타입으로 변경합니다.
2. `Signing & Capabilities` 탭에서 `iCloud` capability를 활성화합니다 (개발자 계정으로 등록되지 않은 팀이므로 생략).

# Results
변경사항을 참조합니다.