### PR TITLE
Managed object fetch 테스트 케이스를 추가합니다.

### DIFF
--- a/iOSScalableAppStructureTests/Core/Data/CoreData/CoreDataTests.swift
+++ b/iOSScalableAppStructureTests/Core/Data/CoreData/CoreDataTests.swift
@@ -10,17 +10,21 @@ import XCTest
 
 class CoreDataTests: XCTestCase {
 
-  func testToManagedObject() throws {
-    // Given
-    let previewContext = PersistenceController.preview.container.viewContext
+  private let sut = PersistenceController.preview.container.viewContext
 
+  override func tearDownWithError() throws {
+    sut.rollback()
+    try super.tearDownWithError()
+  }
+
+  func testToManagedObject() throws {
     // When
     let fetchRequest = AnimalEntity.fetchRequest()
     fetchRequest.fetchLimit = 1
     fetchRequest.sortDescriptors = [
       NSSortDescriptor(keyPath: \AnimalEntity.name, ascending: true)
     ]
-    guard let results = try? previewContext.fetch(fetchRequest),
+    guard let results = try? sut.fetch(fetchRequest),
           let first = results.first else {
       XCTFail("Failed to fetch an animal entity")
       return
@@ -42,24 +46,56 @@ class CoreDataTests: XCTestCase {
   }
 
   func testDeleteManagedObject() throws {
-    // Given
-    let previewContext = PersistenceController.preview.container.viewContext
-
     // When
     let fetchRequest = AnimalEntity.fetchRequest()
-    guard let results = try? previewContext.fetch(fetchRequest),
-          let first = results.first else { return }
+    guard let results = try? sut.fetch(fetchRequest),
+          let first = results.first else {
+      XCTFail("No results")
+      return
+    }
 
     let expectedResult = results.count - 1
-    previewContext.delete(first)
+    sut.delete(first)
 
     // Then
-    guard let resultsAfterDeletion = try? previewContext.fetch(fetchRequest).count else { return }
+    guard let resultsAfterDeletion = try? sut.fetch(fetchRequest).count else {
+      XCTFail("No results")
+      return
+    }
     XCTAssertEqual(
       expectedResult,
       resultsAfterDeletion,
       """
       The number of results was expected to be \(expectedResult) after deletion, was \(results.count)
+      """
+    )
+  }
+
+  func testFetchManagedObject() throws {
+    // When
+    let expectedResultsCount = 1
+    let expectedResultName = "Ellie"
+    let fetchRequest = AnimalEntity.fetchRequest()
+    fetchRequest.fetchLimit = expectedResultsCount
+    fetchRequest.predicate = NSPredicate(format: "name == %@", expectedResultName)
+    guard let results = try? sut.fetch(fetchRequest),
+          let first = results.first else {
+      XCTFail("No results")
+      return
+    }
+
+    XCTAssertEqual(
+      results.count,
+      expectedResultsCount,
+      """
+      The number of results was expected to be \(expectedResultsCount), was \(results.count)
+      """
+    )
+    XCTAssertEqual(
+      first.name,
+      expectedResultName,
+      """
+      Pet name did not match, expecting \(expectedResultName), got \(String(describing: first.name))
       """
     )
   }


### PR DESCRIPTION
# Objectives
1. Managed object fetch 테스트 케이스를 추가합니다. 테스트 실행 순서에 관계 없이 매번 동일한 시작 상태를 보장하기 위해 각 테스트가 종료되면 `NSManagedObjectContext`를 롤백합니다.

# Results
CI 결과를 참조합니다.