### PR TITLE
`AnimalsNearYouView`가 수행하던 네트워크 요청 및 처리 기능을 ViewModel과 Service로 분리합니다.

### DIFF
--- a/iOSScalableAppStructure.xcodeproj/project.pbxproj
+++ b/iOSScalableAppStructure.xcodeproj/project.pbxproj
@@ -23,6 +23,9 @@
 		AA34D7EF2898FFB900D37F26 /* VideoLink+CoreData.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA34D7EE2898FFB900D37F26 /* VideoLink+CoreData.swift */; };
 		AA34D7F128990AF400D37F26 /* CoreDataHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA34D7F028990AF400D37F26 /* CoreDataHelper.swift */; };
 		AA34D7F428990E4900D37F26 /* CoreDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA34D7F328990E4900D37F26 /* CoreDataTests.swift */; };
+		AA80EA7E289D3BBD000BF8DB /* AnimalsNearYouViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA80EA7D289D3BBD000BF8DB /* AnimalsNearYouViewModel.swift */; };
+		AA80EA81289D8E13000BF8DB /* FetchAnimalsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA80EA80289D8E13000BF8DB /* FetchAnimalsService.swift */; };
+		AA80EA83289D8FAA000BF8DB /* AnimalsFetcherMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA80EA82289D8FAA000BF8DB /* AnimalsFetcherMock.swift */; };
 		AAA228092895077F00081167 /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA228082895077F00081167 /* App.swift */; };
 		AAA2280B2895077F00081167 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA2280A2895077F00081167 /* ContentView.swift */; };
 		AAA2280D2895078000081167 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AAA2280C2895078000081167 /* Assets.xcassets */; };
@@ -97,6 +100,9 @@
 		AA34D7EE2898FFB900D37F26 /* VideoLink+CoreData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VideoLink+CoreData.swift"; sourceTree = "<group>"; };
 		AA34D7F028990AF400D37F26 /* CoreDataHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataHelper.swift; sourceTree = "<group>"; };
 		AA34D7F328990E4900D37F26 /* CoreDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataTests.swift; sourceTree = "<group>"; };
+		AA80EA7D289D3BBD000BF8DB /* AnimalsNearYouViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimalsNearYouViewModel.swift; sourceTree = "<group>"; };
+		AA80EA80289D8E13000BF8DB /* FetchAnimalsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchAnimalsService.swift; sourceTree = "<group>"; };
+		AA80EA82289D8FAA000BF8DB /* AnimalsFetcherMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimalsFetcherMock.swift; sourceTree = "<group>"; };
 		AAA228052895077F00081167 /* iOSScalableAppStructure.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSScalableAppStructure.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AAA228082895077F00081167 /* App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App.swift; sourceTree = "<group>"; };
 		AAA2280A2895077F00081167 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -188,6 +194,23 @@
 				AA34D7F328990E4900D37F26 /* CoreDataTests.swift */,
 			);
 			path = CoreData;
+			sourceTree = "<group>";
+		};
+		AA80EA7C289D3BA9000BF8DB /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				AA80EA7D289D3BBD000BF8DB /* AnimalsNearYouViewModel.swift */,
+			);
+			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		AA80EA7F289D8E08000BF8DB /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				AA80EA80289D8E13000BF8DB /* FetchAnimalsService.swift */,
+				AA80EA82289D8FAA000BF8DB /* AnimalsFetcherMock.swift */,
+			);
+			path = Services;
 			sourceTree = "<group>";
 		};
 		AAA227FC2895077F00081167 = {
@@ -351,6 +374,8 @@
 		AAA2282E2896868100081167 /* AnimalsNearYou */ = {
 			isa = PBXGroup;
 			children = (
+				AA80EA7F289D8E08000BF8DB /* Services */,
+				AA80EA7C289D3BA9000BF8DB /* ViewModels */,
 				AAA2282F2896868A00081167 /* Views */,
 			);
 			path = AnimalsNearYou;
@@ -617,6 +642,7 @@
 				AACE3DFC2896EC52005ACB10 /* AuthTokenRequest.swift in Sources */,
 				AACE3DCB2896D2F7005ACB10 /* Animal.swift in Sources */,
 				AA34D7E52898FC2D00D37F26 /* ApiColors+CoreData.swift in Sources */,
+				AA80EA7E289D3BBD000BF8DB /* AnimalsNearYouViewModel.swift in Sources */,
 				AAA228362896870200081167 /* SearchView.swift in Sources */,
 				AA34D7E72898FCC700D37F26 /* Contact+CoreData.swift in Sources */,
 				AACE3DDD2896D64B005ACB10 /* ApiColors.swift in Sources */,
@@ -627,6 +653,7 @@
 				AACE3DD52896D599005ACB10 /* PhotoSizes.swift in Sources */,
 				AACE3E0B2896FB5E005ACB10 /* AccessTokenManager.swift in Sources */,
 				AA34D7E92898FDB000D37F26 /* Organization+CoreData.swift in Sources */,
+				AA80EA81289D8E13000BF8DB /* FetchAnimalsService.swift in Sources */,
 				AACE3DF12896E6D1005ACB10 /* NetworkError.swift in Sources */,
 				AACE3DD32896D576005ACB10 /* Breed.swift in Sources */,
 				AACE3DDF2896D673005ACB10 /* AdoptionStatus.swift in Sources */,
@@ -634,6 +661,7 @@
 				AA34D7EF2898FFB900D37F26 /* VideoLink+CoreData.swift in Sources */,
 				AACE3DE12896D899005ACB10 /* Pagination.swift in Sources */,
 				AA34D7DF2898F20600D37F26 /* Animal+CoreData.swift in Sources */,
+				AA80EA83289D8FAA000BF8DB /* AnimalsFetcherMock.swift in Sources */,
 				AA34D7F128990AF400D37F26 /* CoreDataHelper.swift in Sources */,
 				AACE3DEB2896E455005ACB10 /* RequestType.swift in Sources */,
 				AAA2281E2896854100081167 /* Persistence.swift in Sources */,

--- a/iOSScalableAppStructure/AnimalsNearYou/Services/AnimalsFetcherMock.swift
+++ b/iOSScalableAppStructure/AnimalsNearYou/Services/AnimalsFetcherMock.swift
@@ -1,0 +1,13 @@
+//
+//  AnimalsFetcherMock.swift
+//  iOSScalableAppStructure
+//
+//  Created by Geonhee on 2022/08/06.
+//
+
+struct AnimalsFetcherMock: AnimalsFetcher {
+
+  func fetchAnimals(page: Int) async -> [Animal] {
+    return Animal.mock
+  }
+}

--- a/iOSScalableAppStructure/AnimalsNearYou/Services/FetchAnimalsService.swift
+++ b/iOSScalableAppStructure/AnimalsNearYou/Services/FetchAnimalsService.swift
@@ -1,0 +1,40 @@
+//
+//  FetchAnimalsService.swift
+//  iOSScalableAppStructure
+//
+//  Created by Geonhee on 2022/08/06.
+//
+
+import Foundation
+
+struct FetchAnimalsService {
+
+  private let requestManager: RequestManagerProtocol
+
+  init(
+    requestManager: RequestManagerProtocol
+  ) {
+    self.requestManager = requestManager
+  }
+}
+
+// MARK: - AnimalFetcher
+
+extension FetchAnimalsService: AnimalsFetcher {
+
+  func fetchAnimals(page: Int) async -> [Animal] {
+    let requestData = AnimalsRequest.getAnimalsWith(
+      page: page,
+      latitude: nil,
+      longitude: nil
+    )
+
+    do {
+      let animalsContainer: AnimalsContainer = try await requestManager.perform(requestData)
+      return animalsContainer.animals
+    } catch {
+      print(error.localizedDescription)
+      return []
+    }
+  }
+}

--- a/iOSScalableAppStructure/AnimalsNearYou/ViewModels/AnimalsNearYouViewModel.swift
+++ b/iOSScalableAppStructure/AnimalsNearYou/ViewModels/AnimalsNearYouViewModel.swift
@@ -1,0 +1,38 @@
+//
+//  AnimalsNearYouViewModel.swift
+//  iOSScalableAppStructure
+//
+//  Created by Geonhee on 2022/08/05.
+//
+
+import Foundation
+
+protocol AnimalsFetcher {
+  func fetchAnimals(page: Int) async -> [Animal]
+}
+
+@MainActor
+final class AnimalsNearYouViewModel: ObservableObject {
+  @Published var isLoading: Bool
+  private let animalFetcher: AnimalsFetcher
+
+  init(
+    isLoading: Bool = true,
+    animalFetcher: AnimalsFetcher
+  ) {
+    self.isLoading = isLoading
+    self.animalFetcher = animalFetcher
+  }
+
+  func fetchAnimals() async {
+    Task { @MainActor in
+      let animals = await animalFetcher.fetchAnimals(page: 1)
+
+      for var animal in animals {
+        animal.toManagedObject()
+      }
+
+      self.isLoading = false
+    }
+  }
+}

--- a/iOSScalableAppStructure/ContentView.swift
+++ b/iOSScalableAppStructure/ContentView.swift
@@ -13,14 +13,20 @@ struct ContentView: View {
 
   var body: some View {
     TabView {
-      AnimalsNearYouView()
-        .environment(
-          \.managedObjectContext,
-           managedObjectContext
+      AnimalsNearYouView(
+        viewModel: AnimalsNearYouViewModel(
+          animalFetcher: FetchAnimalsService(
+            requestManager: RequestManager()
+          )
         )
-        .tabItem {
-          Label("Near you", systemImage: "location")
-        }
+      )
+      .environment(
+        \.managedObjectContext,
+         managedObjectContext
+      )
+      .tabItem {
+        Label("Near you", systemImage: "location")
+      }
 
       SearchView()
         .tabItem {


### PR DESCRIPTION
# Background
기존 `AnimalsNearYouView`는 네트워킹 요청과 응답을 수신하여 코어데이터 엔티티 인스턴스로 변환하는 작업을 수행하여 유닛 테스트를 수행하기 까다로운 문제가 있었습니다.

# Objectives
1.  `AnimalsNearYouView`가 수행하던 네트워킹 요청과 처리 기능을 ViewModel로 분리합니다.
2. 추가한 ViewModel이 네트워크 요청을 전담하여 수행하는 Service에 의존하는 구조로 구성하되 Service는 프로토콜을 통해 추상화하여 의존성을 역전시켜 결합도를 낮춥니다.

# Results
리뷰와 diff를 참조합니다.

| | iPhone 13 Pro |
|--|--|
| gif | <img src="https://user-images.githubusercontent.com/69730931/183235703-babc29c7-5d4e-4e2d-ad44-1ed18c68ea4d.gif" width="320"> |