### PR TITLE
`AnimalRow` thumbnail placeholder를 변경합니다.

### DIFF
--- a/iOSScalableAppStructure/AnimalsNearYou/Views/AnimalRow.swift
+++ b/iOSScalableAppStructure/AnimalsNearYou/Views/AnimalRow.swift
@@ -19,13 +19,16 @@ struct AnimalRow: View {
           image.resizable()
         },
         placeholder: {
-          Image(systemName: "swift")
-            .resizable()
+          RoundedRectangle(cornerRadius: 8)
+            .strokeBorder(Color.gray.opacity(0.4), lineWidth: 1)
+            .background(Color.gray.opacity(0.1))
             .overlay {
               if animal.picture != nil {
                 ProgressView()
                   .frame(maxWidth: .infinity, maxHeight: .infinity)
-                  .background(.gray.opacity(0.4))
+                  .background(.gray.opacity(0.1))
+              } else {
+                Text("No Image")
               }
             }
         }


### PR DESCRIPTION
# Related PRs
- #13 

# Background
기존 `AnimalRow`의 썸네일은 검은색 아이콘을 사용하고 있어 loading indicator가 보이지 않는 문제가 있었습니다.

# Objectives
1. 썸네일 placeholder를 변경하여 이미지를 불러오는 중에 loading indicator가 보이게 합니다.
2. 제공되는 이미지가 없는 경우에는 `No Image`라는 문구를 표시하여 사용자가 이미지의 상태를 파악할 수 있게 합니다.

# Results
| | iPhone 13 Pro |
|--|--|
| gif | <img src="https://user-images.githubusercontent.com/69730931/183237019-c0e3ccdb-bf3c-4e9e-aedb-0a005df8ba6a.gif" width="320"> |