### PR TITLE
`PersistenceController`가 in memory 상태가 아닐 때 store를 불러오지 않던 문제를 수정합니다.

### DIFF
--- a/iOSScalableAppStructure/Core/Data/CoreData/Persistence.swift
+++ b/iOSScalableAppStructure/Core/Data/CoreData/Persistence.swift
@@ -39,15 +39,15 @@ struct PersistenceController {
         .persistentStoreDescriptions
         .first?
         .url = URL(fileURLWithPath: "/dev/null")
-
-      container.loadPersistentStores { _, error in
-        if let error = error as NSError? {
-          fatalError("Unresolved error \(error), \(error.userInfo)")
-        }
-      }
-      container.viewContext.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
-      container.viewContext.automaticallyMergesChangesFromParent = true
     }
+
+    container.loadPersistentStores { _, error in
+      if let error = error as NSError? {
+        fatalError("Unresolved error \(error), \(error.userInfo)")
+      }
+    }
+    container.viewContext.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
+    container.viewContext.automaticallyMergesChangesFromParent = true
   }
 
   static func save() {


### PR DESCRIPTION
# Related PRs
- #18

# Background
네트워크 응답을 통해 받은 `Animal` 도메인 모델 인스턴스를 다중 스레드 환경에서 Core Data DB에 `AnimalEntity` 형태의 코어데이터 엔티티로 저장하기 위해 Background context를 생성을 시도하던 중 아래와 같은 런타임 에러가 발생했습니다.

```
Thread 1: "This NSPersistentStoreCoordinator has no persistent stores (unknown).  It cannot perform a save operation."
```

추가로 콘솔에는 아래와 같은 에러 문구가 출력되었습니다.

```
CoreData: warning:  Background context created for persistent container iOSScalableAppStructure with no stores loaded
```

# Root cause
`PersistenceController`의 이니셜라이저에 테스트를 위한 inMemory 환경일 때 `NSPersistentContainer`의 URL path를 `/dev/null`로 지정하는 코드만 포함되어야하나, scope의 착오로 인해 이니셜라이저의 전체 코드가 `if`문에 포함되어 있었습니다.

# Objectives
1. `if` 문의 scope만 의도한 범위로 변경하여 배경에서 발생한 런타임 에러와 경고를 해결합니다.



# Results
1. 런타임 에러와 경고가 나타나지 않습니다.

| | iPhone 13 Pro |
|--|--|
| gif | <img src="https://user-images.githubusercontent.com/69730931/183238688-38f511e0-5848-44a4-ad3f-e1deef026183.gif" width="320"> |
