### PR TITLE
`AnimalEntity`를 CoreData DB에 저장하는 역할을 수행하는`AnimalStore`를 추가합니다.

### DIFF
--- a/iOSScalableAppStructure.xcodeproj/project.pbxproj
+++ b/iOSScalableAppStructure.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		AA80EA7E289D3BBD000BF8DB /* AnimalsNearYouViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA80EA7D289D3BBD000BF8DB /* AnimalsNearYouViewModel.swift */; };
 		AA80EA81289D8E13000BF8DB /* FetchAnimalsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA80EA80289D8E13000BF8DB /* FetchAnimalsService.swift */; };
 		AA80EA83289D8FAA000BF8DB /* AnimalsFetcherMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA80EA82289D8FAA000BF8DB /* AnimalsFetcherMock.swift */; };
+		AA80EA85289E4444000BF8DB /* AnimalStoreService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA80EA84289E4444000BF8DB /* AnimalStoreService.swift */; };
 		AAA228092895077F00081167 /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA228082895077F00081167 /* App.swift */; };
 		AAA2280B2895077F00081167 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA2280A2895077F00081167 /* ContentView.swift */; };
 		AAA2280D2895078000081167 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AAA2280C2895078000081167 /* Assets.xcassets */; };
@@ -103,6 +104,7 @@
 		AA80EA7D289D3BBD000BF8DB /* AnimalsNearYouViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimalsNearYouViewModel.swift; sourceTree = "<group>"; };
 		AA80EA80289D8E13000BF8DB /* FetchAnimalsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchAnimalsService.swift; sourceTree = "<group>"; };
 		AA80EA82289D8FAA000BF8DB /* AnimalsFetcherMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimalsFetcherMock.swift; sourceTree = "<group>"; };
+		AA80EA84289E4444000BF8DB /* AnimalStoreService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimalStoreService.swift; sourceTree = "<group>"; };
 		AAA228052895077F00081167 /* iOSScalableAppStructure.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSScalableAppStructure.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AAA228082895077F00081167 /* App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App.swift; sourceTree = "<group>"; };
 		AAA2280A2895077F00081167 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -207,8 +209,9 @@
 		AA80EA7F289D8E08000BF8DB /* Services */ = {
 			isa = PBXGroup;
 			children = (
-				AA80EA80289D8E13000BF8DB /* FetchAnimalsService.swift */,
 				AA80EA82289D8FAA000BF8DB /* AnimalsFetcherMock.swift */,
+				AA80EA84289E4444000BF8DB /* AnimalStoreService.swift */,
+				AA80EA80289D8E13000BF8DB /* FetchAnimalsService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -645,6 +648,7 @@
 				AA80EA7E289D3BBD000BF8DB /* AnimalsNearYouViewModel.swift in Sources */,
 				AAA228362896870200081167 /* SearchView.swift in Sources */,
 				AA34D7E72898FCC700D37F26 /* Contact+CoreData.swift in Sources */,
+				AA80EA85289E4444000BF8DB /* AnimalStoreService.swift in Sources */,
 				AACE3DDD2896D64B005ACB10 /* ApiColors.swift in Sources */,
 				AACE3DFF2896ED85005ACB10 /* ApiToken.swift in Sources */,
 				AACE3DE92896E3D9005ACB10 /* RequestProtocol.swift in Sources */,

--- a/iOSScalableAppStructure/AnimalsNearYou/Services/AnimalStoreService.swift
+++ b/iOSScalableAppStructure/AnimalsNearYou/Services/AnimalStoreService.swift
@@ -1,0 +1,30 @@
+//
+//  AnimalStoreService.swift
+//  iOSScalableAppStructure
+//
+//  Created by Geonhee on 2022/08/06.
+//
+
+import CoreData
+
+struct AnimalStoreService {
+
+  private let context: NSManagedObjectContext
+
+  init(
+    context: NSManagedObjectContext
+  ) {
+    self.context = context
+  }
+}
+
+extension AnimalStoreService : AnimalStore {
+
+  func save(animals: [Animal]) async throws {
+    for var animal in animals {
+      animal.toManagedObject(context: context)
+    }
+
+    try context.save()
+  }
+}

--- a/iOSScalableAppStructure/AnimalsNearYou/ViewModels/AnimalsNearYouViewModel.swift
+++ b/iOSScalableAppStructure/AnimalsNearYou/ViewModels/AnimalsNearYouViewModel.swift
@@ -11,25 +11,35 @@ protocol AnimalsFetcher {
   func fetchAnimals(page: Int) async -> [Animal]
 }
 
+protocol AnimalStore {
+  func save(animals: [Animal]) async throws
+}
+
 @MainActor
 final class AnimalsNearYouViewModel: ObservableObject {
+
   @Published var isLoading: Bool
   private let animalFetcher: AnimalsFetcher
+  private let animalStore: AnimalStore
 
   init(
     isLoading: Bool = true,
-    animalFetcher: AnimalsFetcher
+    animalFetcher: AnimalsFetcher,
+    animalStore: AnimalStore
   ) {
     self.isLoading = isLoading
     self.animalFetcher = animalFetcher
+    self.animalStore = animalStore
   }
 
   func fetchAnimals() async {
     Task { @MainActor in
       let animals = await animalFetcher.fetchAnimals(page: 1)
 
-      for var animal in animals {
-        animal.toManagedObject()
+      do {
+        try await animalStore.save(animals: animals)
+      } catch {
+        print("Error storing animals... \(error.localizedDescription)")
       }
 
       self.isLoading = false

--- a/iOSScalableAppStructure/AnimalsNearYou/Views/AnimalsNearYouView.swift
+++ b/iOSScalableAppStructure/AnimalsNearYou/Views/AnimalsNearYouView.swift
@@ -55,7 +55,8 @@ struct AnimalsNearYouView_Previews: PreviewProvider {
   static var previews: some View {
     AnimalsNearYouView(
       viewModel: AnimalsNearYouViewModel(
-        animalFetcher: AnimalsFetcherMock()
+        animalFetcher: AnimalsFetcherMock(),
+        animalStore: AnimalStoreService(context: CoreDataHelper.previewContext)
       )
     )
     .environment(

--- a/iOSScalableAppStructure/ContentView.swift
+++ b/iOSScalableAppStructure/ContentView.swift
@@ -17,6 +17,9 @@ struct ContentView: View {
         viewModel: AnimalsNearYouViewModel(
           animalFetcher: FetchAnimalsService(
             requestManager: RequestManager()
+          ),
+          animalStore: AnimalStoreService(
+            context: PersistenceController.shared.container.newBackgroundContext()
           )
         )
       )


### PR DESCRIPTION
# Related PRs
- #31

# Background
Single Response Principle (SRP)에 따라 하나의 모듈, 타입과 메서드는 최대한 하나의 역할을 수행하는 것이 바람직합니다. 기존 `AnimalsNearYouViewModel`의 `fetchAnimals()` 메서드는 `AnimalsFetcher` 프로토콜을 준수하는 `FetchAnimalService`를 통해 네트워크 요청을 통해 데이터를 가져오고 도메인 모델 인스턴스로 변환하는 역할을 분리했으나 CoreData에 엔티티를 저장하는 역할을 분리하지는 않았습니다.

# Objectives
1. 도메인 모델 인스턴스를 코어데이터 엔티티 인스턴스로 변환하고 CoreData DB에 저장하는 역할을 수행하는 타입을 정의하고 적용합니다.

# Results
1. `AnimalStore` 프로토콜과 `AnimalStoreService` 구조체를 참고합니다.