### PR TITLE
`AnimalsNearYouVIew` 리스트에 infinite scrolling 기능을 추가하고 Section을 제거합니다.

### DIFF
--- a/iOSScalableAppStructure/AnimalsNearYou/ViewModels/AnimalsNearYouViewModel.swift
+++ b/iOSScalableAppStructure/AnimalsNearYou/ViewModels/AnimalsNearYouViewModel.swift
@@ -18,9 +18,12 @@ protocol AnimalStore {
 @MainActor
 final class AnimalsNearYouViewModel: ObservableObject {
 
-  @Published var isLoading: Bool
   private let animalFetcher: AnimalsFetcher
   private let animalStore: AnimalStore
+
+  @Published var isLoading: Bool
+  @Published var hasMoreAnimals = true
+  private(set) var page = 1
 
   init(
     isLoading: Bool = true,
@@ -34,7 +37,7 @@ final class AnimalsNearYouViewModel: ObservableObject {
 
   func fetchAnimals() async {
     Task { @MainActor in
-      let animals = await animalFetcher.fetchAnimals(page: 1)
+      let animals = await animalFetcher.fetchAnimals(page: page)
 
       do {
         try await animalStore.save(animals: animals)
@@ -43,6 +46,12 @@ final class AnimalsNearYouViewModel: ObservableObject {
       }
 
       self.isLoading = false
+      self.hasMoreAnimals = animals.isNotEmpty
     }
+  }
+
+  func fetchMoreAnimals() async {
+    page += 1
+    await fetchAnimals()
   }
 }

--- a/iOSScalableAppStructure/Core/Utilities/Occupiable.swift
+++ b/iOSScalableAppStructure/Core/Utilities/Occupiable.swift
@@ -5,6 +5,8 @@
 //  Created by Geonhee on 2022/08/01.
 //
 
+import struct SwiftUI.FetchedResults
+
 protocol Occupiable {
   var isEmpty: Bool { get }
   var isNotEmpty: Bool { get }
@@ -17,6 +19,7 @@ extension Occupiable {
 }
 
 extension AnyCollection: Occupiable {}
+extension FetchedResults: Occupiable {}
 extension Dictionary: Occupiable {}
 extension Array: Occupiable {}
 extension String: Occupiable {}


### PR DESCRIPTION
# Background
`AnimalsNearYouView`에는 pagination 기능이 없어 더 많은 아이템을 불러오지 못했습니다.

# Objectives
1. `AnimalsNearYouView`에 pagination 기능을 추가하여 더 많은 아이템을 리스트에서 볼 수 있도록 합니다.
2. 가져온 아이템이 추가되는 모습을 잘 보여주기 위해 섹션을 제거합니다.

# Results
| | iPhone 13 Pro |
|--|--|
| gif | <img src="https://user-images.githubusercontent.com/69730931/183244156-4d7112f2-b172-4f51-8399-e4e84450032f.gif" width="320"> |