### PR TITLE
`fetchAnimals()` 메서드 호출과 응답에 따른 `AnimalsNearYouViewModel`의 로딩 상태를 검증하는 테스트 케이스를 추가합니다.

### DIFF
--- a/iOSScalableAppStructure.xcodeproj/project.pbxproj
+++ b/iOSScalableAppStructure.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		AA34D7F128990AF400D37F26 /* CoreDataHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA34D7F028990AF400D37F26 /* CoreDataHelper.swift */; };
 		AA34D7F428990E4900D37F26 /* CoreDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA34D7F328990E4900D37F26 /* CoreDataTests.swift */; };
 		AA3B5108289E778300C5164C /* AnimalAttributesCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3B5107289E778300C5164C /* AnimalAttributesCard.swift */; };
+		AA3B510B289E812A00C5164C /* AnimalsNearYouViewModelTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3B510A289E812A00C5164C /* AnimalsNearYouViewModelTestCase.swift */; };
 		AA80EA7E289D3BBD000BF8DB /* AnimalsNearYouViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA80EA7D289D3BBD000BF8DB /* AnimalsNearYouViewModel.swift */; };
 		AA80EA81289D8E13000BF8DB /* FetchAnimalsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA80EA80289D8E13000BF8DB /* FetchAnimalsService.swift */; };
 		AA80EA83289D8FAA000BF8DB /* AnimalsFetcherMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA80EA82289D8FAA000BF8DB /* AnimalsFetcherMock.swift */; };
@@ -103,6 +104,7 @@
 		AA34D7F028990AF400D37F26 /* CoreDataHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataHelper.swift; sourceTree = "<group>"; };
 		AA34D7F328990E4900D37F26 /* CoreDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataTests.swift; sourceTree = "<group>"; };
 		AA3B5107289E778300C5164C /* AnimalAttributesCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimalAttributesCard.swift; sourceTree = "<group>"; };
+		AA3B510A289E812A00C5164C /* AnimalsNearYouViewModelTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimalsNearYouViewModelTestCase.swift; sourceTree = "<group>"; };
 		AA80EA7D289D3BBD000BF8DB /* AnimalsNearYouViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimalsNearYouViewModel.swift; sourceTree = "<group>"; };
 		AA80EA80289D8E13000BF8DB /* FetchAnimalsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchAnimalsService.swift; sourceTree = "<group>"; };
 		AA80EA82289D8FAA000BF8DB /* AnimalsFetcherMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimalsFetcherMock.swift; sourceTree = "<group>"; };
@@ -198,6 +200,14 @@
 				AA34D7F328990E4900D37F26 /* CoreDataTests.swift */,
 			);
 			path = CoreData;
+			sourceTree = "<group>";
+		};
+		AA3B5109289E810D00C5164C /* AnimalsNearYou */ = {
+			isa = PBXGroup;
+			children = (
+				AA3B510A289E812A00C5164C /* AnimalsNearYouViewModelTestCase.swift */,
+			);
+			path = AnimalsNearYou;
 			sourceTree = "<group>";
 		};
 		AA80EA7C289D3BA9000BF8DB /* ViewModels */ = {
@@ -415,6 +425,7 @@
 		AAA2283C2896879400081167 /* iOSScalableAppStructureTests */ = {
 			isa = PBXGroup;
 			children = (
+				AA3B5109289E810D00C5164C /* AnimalsNearYou */,
 				AACE3E0E2897D5DE005ACB10 /* Core */,
 			);
 			path = iOSScalableAppStructureTests;
@@ -712,6 +723,7 @@
 				AA34D7F428990E4900D37F26 /* CoreDataTests.swift in Sources */,
 				AACE3E142897D623005ACB10 /* ApiManagerMock.swift in Sources */,
 				AACF52A12897D964001856C5 /* AnimalsRequestMock.swift in Sources */,
+				AA3B510B289E812A00C5164C /* AnimalsNearYouViewModelTestCase.swift in Sources */,
 				AA34D7922897F7D800D37F26 /* AccessTokenManagerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/iOSScalableAppStructureTests/AnimalsNearYou/AnimalsNearYouViewModelTestCase.swift
+++ b/iOSScalableAppStructureTests/AnimalsNearYou/AnimalsNearYouViewModelTestCase.swift
@@ -1,0 +1,34 @@
+//
+//  AnimalsNearYouViewModelTestCase.swift
+//  iOSScalableAppStructureTests
+//
+//  Created by Geonhee on 2022/08/06.
+//
+
+import XCTest
+@testable import iOSScalableAppStructure
+
+@MainActor
+final class AnimalsNearYouViewModelTestCase: XCTestCase {
+
+  let testContext = PersistenceController.preview.container.viewContext
+  var viewModel: AnimalsNearYouViewModel!
+
+  @MainActor
+  override func setUp() {
+    super.setUp()
+    viewModel = AnimalsNearYouViewModel(
+      isLoading: true,
+      animalFetcher: AnimalsFetcherMock(),
+      animalStore: AnimalStoreService(context: testContext)
+    )
+  }
+
+  func testFetchAnimalsLoadingState() {
+    Task { @MainActor in
+      XCTAssertTrue(viewModel.isLoading, "The view model should be loading, but it isn't")
+      await viewModel.fetchAnimals()
+      XCTAssertFalse(viewModel.isLoading, "The view model shouldn't be loading, but it is")
+    }
+  }
+}


### PR DESCRIPTION
# Objectives
1. `fetchAnimals()` 메서드 호출과 응답에 따른 `AnimalsNearYouViewModel`의 로딩 상태를 검증합니다.

# Results
1. 유닛 테스트를 통과했습니다. 자세한 사항은 변경사항을 참조합니다.
<img width="327" alt="image" src="https://user-images.githubusercontent.com/69730931/183274494-a7ced1c5-b2ce-4238-9253-0656b12ae9fd.png">
