### PR TITLE
`AnimalsNearYouViewModel`의 페이지네이션 테스트를 추가합니다.

### DIFF
--- a/iOSScalableAppStructure.xcodeproj/project.pbxproj
+++ b/iOSScalableAppStructure.xcodeproj/project.pbxproj
@@ -210,6 +210,13 @@
 			path = AnimalsNearYou;
 			sourceTree = "<group>";
 		};
+		AA3B510C289F90F600C5164C /* Helper */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Helper;
+			sourceTree = "<group>";
+		};
 		AA80EA7C289D3BA9000BF8DB /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
@@ -425,6 +432,7 @@
 		AAA2283C2896879400081167 /* iOSScalableAppStructureTests */ = {
 			isa = PBXGroup;
 			children = (
+				AA3B510C289F90F600C5164C /* Helper */,
 				AA3B5109289E810D00C5164C /* AnimalsNearYou */,
 				AACE3E0E2897D5DE005ACB10 /* Core */,
 			);

--- a/iOSScalableAppStructureTests/AnimalsNearYou/AnimalsNearYouViewModelTestCase.swift
+++ b/iOSScalableAppStructureTests/AnimalsNearYou/AnimalsNearYouViewModelTestCase.swift
@@ -8,27 +8,78 @@
 import XCTest
 @testable import iOSScalableAppStructure
 
-@MainActor
 final class AnimalsNearYouViewModelTestCase: XCTestCase {
 
   let testContext = PersistenceController.preview.container.viewContext
-  var viewModel: AnimalsNearYouViewModel!
+  var sut: AnimalsNearYouViewModel!
 
-  @MainActor
   override func setUp() {
-    super.setUp()
-    viewModel = AnimalsNearYouViewModel(
-      isLoading: true,
-      animalFetcher: AnimalsFetcherMock(),
-      animalStore: AnimalStoreService(context: testContext)
-    )
+    Task { @MainActor in
+      try await super.setUp()
+      sut = AnimalsNearYouViewModel(
+        isLoading: true,
+        animalFetcher: AnimalsFetcherMock(),
+        animalStore: AnimalStoreService(context: testContext)
+      )
+    }
+  }
+
+  override func tearDown() {
+    Task { @MainActor in
+      sut = nil
+      try await super.tearDown()
+    }
   }
 
   func testFetchAnimalsLoadingState() {
     Task { @MainActor in
-      XCTAssertTrue(viewModel.isLoading, "The view model should be loading, but it isn't")
-      await viewModel.fetchAnimals()
-      XCTAssertFalse(viewModel.isLoading, "The view model shouldn't be loading, but it is")
+      XCTAssertTrue(sut.isLoading, "The view model should be loading, but it isn't")
+      await sut.fetchAnimals()
+      XCTAssertFalse(sut.isLoading, "The view model shouldn't be loading, but it is")
     }
+  }
+
+  func testUpdatePageOnFetchMoreAnimals() {
+    Task { @MainActor in
+      XCTAssertEqual(
+        sut.page,
+        1,
+        "the view model's page property should be 1 before fetching, but it's \(sut.page)"
+      )
+      await sut.fetchAnimals()
+      XCTAssertEqual(
+        sut.page,
+        2,
+        "the view model's page property should be 2 after fetching, but it's \(sut.page)"
+      )
+    }
+  }
+
+  func testFetchAnimalsEmptyResponse() {
+    Task { @MainActor in
+      sut = AnimalsNearYouViewModel(
+        isLoading: true,
+        animalFetcher: EmptyResponseAnimalsFetcherMock(),
+        animalStore: AnimalStoreService(context: testContext)
+      )
+
+      await sut.fetchAnimals()
+
+      XCTAssertFalse(
+        sut.hasMoreAnimals,
+        "hasMoreAnimals should be false with an empty response, but it's true"
+      )
+      XCTAssertFalse(
+        sut.isLoading,
+        "the view model shouldn't be loading after receiving an empty response, but it is"
+      )
+    }
+  }
+}
+
+struct EmptyResponseAnimalsFetcherMock: AnimalsFetcher {
+
+  func fetchAnimals(page: Int) async -> [Animal] {
+    return []
   }
 }

--- a/iOSScalableAppStructureTests/AnimalsNearYou/AnimalsNearYouViewModelTestCase.swift
+++ b/iOSScalableAppStructureTests/AnimalsNearYou/AnimalsNearYouViewModelTestCase.swift
@@ -13,58 +13,50 @@ final class AnimalsNearYouViewModelTestCase: XCTestCase {
   let testContext = PersistenceController.preview.container.viewContext
   var sut: AnimalsNearYouViewModel!
 
-  override func setUp() {
-    Task { @MainActor in
-      try await super.setUp()
-      sut = AnimalsNearYouViewModel(
-        isLoading: true,
-        animalFetcher: AnimalsFetcherMock(),
-        animalStore: AnimalStoreService(context: testContext)
-      )
-    }
+  override func setUp() async throws {
+    try await super.setUp()
+    sut = AnimalsNearYouViewModel(
+      isLoading: true,
+      animalFetcher: AnimalsFetcherMock(),
+      animalStore: AnimalStoreService(context: testContext)
+    )
   }
 
-  override func tearDown() {
-    Task { @MainActor in
-      sut = nil
-      try await super.tearDown()
-    }
+  override func tearDown() async throws {
+    sut = nil
+    try await super.tearDown()
   }
 
-  func testFetchAnimalsLoadingState() {
-    Task { @MainActor in
-      XCTAssertTrue(sut.isLoading, "The view model should be loading, but it isn't")
-      await sut.fetchAnimals()
-      XCTAssertFalse(sut.isLoading, "The view model shouldn't be loading, but it is")
-    }
+  func testFetchAnimalsLoadingState() async {
+    XCTAssertTrue(sut.isLoading, "The view model should be loading, but it isn't")
+    await sut.fetchAnimals()
+    XCTAssertFalse(sut.isLoading, "The view model shouldn't be loading, but it is")
   }
 
-  func testUpdatePageOnFetchMoreAnimals() {
-    Task { @MainActor in
-      XCTAssertEqual(
-        sut.page,
-        1,
-        "the view model's page property should be 1 before fetching, but it's \(sut.page)"
-      )
-      await sut.fetchAnimals()
-      XCTAssertEqual(
-        sut.page,
-        2,
-        "the view model's page property should be 2 after fetching, but it's \(sut.page)"
-      )
-    }
+  func testUpdatePageOnFetchMoreAnimals() async {
+    XCTAssertEqual(
+      sut.page,
+      1,
+      "the view model's page property should be 1 before fetching, but it's \(sut.page)"
+    )
+    await sut.fetchMoreAnimals()
+    XCTAssertEqual(
+      sut.page,
+      2,
+      "the view model's page property should be 2 after fetching, but it's \(sut.page)"
+    )
   }
 
-  func testFetchAnimalsEmptyResponse() {
-    Task { @MainActor in
-      sut = AnimalsNearYouViewModel(
-        isLoading: true,
-        animalFetcher: EmptyResponseAnimalsFetcherMock(),
-        animalStore: AnimalStoreService(context: testContext)
-      )
+  func testFetchAnimalsEmptyResponse() async {
+    sut = AnimalsNearYouViewModel(
+      isLoading: true,
+      animalFetcher: EmptyResponseAnimalsFetcherMock(),
+      animalStore: AnimalStoreService(context: testContext)
+    )
 
-      await sut.fetchAnimals()
+    let animals = await sut.fetchAnimals()
 
+    if animals.isNotEmpty {
       XCTAssertFalse(
         sut.hasMoreAnimals,
         "hasMoreAnimals should be false with an empty response, but it's true"


### PR DESCRIPTION
# Related PRs
- #37 

# Objectives
1. `AnimalsNearYouViewModel`의 `page` 프로퍼티가 최초 1에서 `fetchAnimals()`를 호출하면 2로 변경되는지 확인합니다.
2. `fetchAnimals()`이 빈 배열을 반환하면 `hasMoreAnimals`와 `isLoading` 프로퍼티가 `false`인지 확인합니다.

# Results
<img width="338" alt="image" src="https://user-images.githubusercontent.com/69730931/183275888-ffd60781-12e0-4a31-9f6b-cd2b092fe007.png">
