### PR TITLE
GitHub Actions CI 환경의 Xcode 버전을 안정적인 최신버전으로 설정합니다.

### DIFF
--- a/.github/workflows/test_every_push_and_PR.yml
+++ b/.github/workflows/test_every_push_and_PR.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Setup Xcode version to latest-stable
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
       - name: Set Default Scheme
         run: |
           scheme_list=$(xcodebuild -list -json | tr -d "\n")

--- a/.github/workflows/test_every_push_and_PR.yml
+++ b/.github/workflows/test_every_push_and_PR.yml
@@ -9,15 +9,11 @@ on:
 jobs:
   build:
 
-    runs-on: macos-latest
+    runs-on: macos-12
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Setup Xcode version to latest-stable
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: latest-stable
       - name: Set Default Scheme
         run: |
           scheme_list=$(xcodebuild -list -json | tr -d "\n")


### PR DESCRIPTION
# Background
최신 API들은 Xcode (Swift 컴파일러) 버전 에 따라 다른 방식으로 동작하는 경우가 있습니다.

# Objectives
1. GitHub Actions CI 환경의 Xcode 버전을 안정적인 최신버전으로 설정합니다.

- GitHub Actions의 macos-latest 가상 환경은 MacOS 11을 의미하며 [Xcode13.2.1까지만 지원합니다](https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md).
- macos-12는 [Xcode 13.4.1까지 지원합니다](https://github.com/actions/virtual-environments/blob/main/images/macos/macos-12-Readme.md).
- 이에따라 MacOS 버전을 `macos-latest`에서 `macos-12`로 변경합니다.

# Results
1. 변경사항을 참조합니다.