### PR TITLE
`AnimalListView` 공용 뷰 컴포넌트로 만들고 `SearchView`에 적용합니다.

### DIFF
--- a/iOSScalableAppStructure.xcodeproj/project.pbxproj
+++ b/iOSScalableAppStructure.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		AA34D7F428990E4900D37F26 /* CoreDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA34D7F328990E4900D37F26 /* CoreDataTests.swift */; };
 		AA3B5108289E778300C5164C /* AnimalAttributesCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3B5107289E778300C5164C /* AnimalAttributesCard.swift */; };
 		AA3B510B289E812A00C5164C /* AnimalsNearYouViewModelTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3B510A289E812A00C5164C /* AnimalsNearYouViewModelTestCase.swift */; };
+		AA3B5111289FBFCE00C5164C /* AnimalListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3B5110289FBFCE00C5164C /* AnimalListView.swift */; };
 		AA80EA7E289D3BBD000BF8DB /* AnimalsNearYouViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA80EA7D289D3BBD000BF8DB /* AnimalsNearYouViewModel.swift */; };
 		AA80EA81289D8E13000BF8DB /* FetchAnimalsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA80EA80289D8E13000BF8DB /* FetchAnimalsService.swift */; };
 		AA80EA83289D8FAA000BF8DB /* AnimalsFetcherMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA80EA82289D8FAA000BF8DB /* AnimalsFetcherMock.swift */; };
@@ -105,6 +106,7 @@
 		AA34D7F328990E4900D37F26 /* CoreDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataTests.swift; sourceTree = "<group>"; };
 		AA3B5107289E778300C5164C /* AnimalAttributesCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimalAttributesCard.swift; sourceTree = "<group>"; };
 		AA3B510A289E812A00C5164C /* AnimalsNearYouViewModelTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimalsNearYouViewModelTestCase.swift; sourceTree = "<group>"; };
+		AA3B5110289FBFCE00C5164C /* AnimalListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimalListView.swift; sourceTree = "<group>"; };
 		AA80EA7D289D3BBD000BF8DB /* AnimalsNearYouViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimalsNearYouViewModel.swift; sourceTree = "<group>"; };
 		AA80EA80289D8E13000BF8DB /* FetchAnimalsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchAnimalsService.swift; sourceTree = "<group>"; };
 		AA80EA82289D8FAA000BF8DB /* AnimalsFetcherMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimalsFetcherMock.swift; sourceTree = "<group>"; };
@@ -217,6 +219,14 @@
 			path = Helper;
 			sourceTree = "<group>";
 		};
+		AA3B510F289FBFBE00C5164C /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				AA3B5110289FBFCE00C5164C /* AnimalListView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
 		AA80EA7C289D3BA9000BF8DB /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
@@ -283,6 +293,7 @@
 				AAA228172896656500081167 /* Data */,
 				AAA2281F2896859000081167 /* Domain */,
 				AACE3DEC2896E54E005ACB10 /* Utilities */,
+				AA3B510F289FBFBE00C5164C /* Views */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -719,6 +730,7 @@
 				AACE3DE32896DD5B005ACB10 /* AnimalsMock.swift in Sources */,
 				AAA22829289685FC00081167 /* User.swift in Sources */,
 				AACE3E082896F46A005ACB10 /* AnimalRow.swift in Sources */,
+				AA3B5111289FBFCE00C5164C /* AnimalListView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOSScalableAppStructure/AnimalsNearYou/Views/AnimalsNearYouView.swift
+++ b/iOSScalableAppStructure/AnimalsNearYou/Views/AnimalsNearYouView.swift
@@ -20,13 +20,7 @@ struct AnimalsNearYouView: View {
 
   var body: some View {
     NavigationView {
-      List {
-        ForEach(animals) { animal in
-          NavigationLink(destination: AnimalDetailsView.init) {
-            AnimalRow(animal: animal)
-          }
-        }
-
+      AnimalListView(animals: animals) {
         if animals.isNotEmpty && viewModel.hasMoreAnimals {
           ProgressView("Finding more animals...")
             .padding()

--- a/iOSScalableAppStructure/ContentView.swift
+++ b/iOSScalableAppStructure/ContentView.swift
@@ -23,10 +23,6 @@ struct ContentView: View {
           )
         )
       )
-      .environment(
-        \.managedObjectContext,
-         managedObjectContext
-      )
       .tabItem {
         Label("Near you", systemImage: "location")
       }
@@ -36,6 +32,7 @@ struct ContentView: View {
           Label("Search", systemImage: "magnifyingglass")
         }
     }
+    .environment(\.managedObjectContext,managedObjectContext)
   }
 }
 

--- a/iOSScalableAppStructure/Core/Views/AnimalListView.swift
+++ b/iOSScalableAppStructure/Core/Views/AnimalListView.swift
@@ -1,0 +1,59 @@
+//
+//  AnimalListView.swift
+//  iOSScalableAppStructure
+//
+//  Created by Geonhee on 2022/08/07.
+//
+
+import SwiftUI
+
+struct AnimalListView<Content, Data>: View
+where Content: View,
+      Data: RandomAccessCollection,
+      Data.Element: AnimalEntity {
+
+  let animals: Data
+  let footer: Content
+
+  init(
+    animals: Data,
+    @ViewBuilder footer: () -> Content
+  ) {
+    self.animals = animals
+    self.footer = footer()
+  }
+
+  init(animals: Data) where Content == EmptyView {
+    self.init(
+      animals: animals,
+      footer: EmptyView.init
+    )
+  }
+
+  var body: some View {
+    List {
+      ForEach(animals) { animal in
+        NavigationLink(destination: AnimalDetailsView.init) {
+          AnimalRow(animal: animal)
+        }
+      }
+
+      footer
+    }
+    .listStyle(.plain)
+  }
+}
+
+struct AnimalListView_Previews: PreviewProvider {
+  static var previews: some View {
+    NavigationView {
+      AnimalListView(animals: CoreDataHelper.testAnimalEntities() ?? [])
+    }
+
+    NavigationView {
+      AnimalListView(animals: []) {
+        Text("This is a footer")
+      }
+    }
+  }
+}

--- a/iOSScalableAppStructure/Search/Views/SearchView.swift
+++ b/iOSScalableAppStructure/Search/Views/SearchView.swift
@@ -8,23 +8,29 @@
 import SwiftUI
 
 struct SearchView: View {
+
+  @FetchRequest(
+    sortDescriptors: [
+      NSSortDescriptor(
+        keyPath: \AnimalEntity.timestamp,
+        ascending: true
+      )
+    ],
+    animation: .default
+  )
+  private var animals: FetchedResults<AnimalEntity>
+
   var body: some View {
-    Text("TODO: Search")
+    NavigationView {
+      AnimalListView(animals: animals)
+      .navigationTitle("Find your future pet")
+    }
+    .navigationViewStyle(.stack)
   }
 }
 
 struct SearchView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
-      SearchView()
-    }
-    .previewLayout(.sizeThatFits)
-    .previewDisplayName("iPhone SE (2nd generation)")
-
-    NavigationView {
-      SearchView()
-    }
-    .previewDevice("iPhone 12 Pro")
-    .previewDisplayName("iPhone 12 Pro")
+    SearchView()
   }
 }


### PR DESCRIPTION
# Background
- `SearchView`에 사용될 리스트는 `AnimalsNearYouView`에 사용되었던 리스트와 동일한 디자인입니다.

# Objectives
1. `AnimalsNearYouView`에 구현한 리스트 뷰를 공통 뷰 컴포넌트로 만들어 `SearchView`에 적용합니다.

# Results
<img src="https://user-images.githubusercontent.com/69730931/183287056-233fe2db-646a-49aa-a33f-7e724fe843c9.gif" width="320">
