### PR TITLE
프리뷰와 유닛 테스트를 위한 `AnimalSearchServiceMock`를 추가합니다.

### DIFF
--- a/iOSScalableAppStructure.xcodeproj/project.pbxproj
+++ b/iOSScalableAppStructure.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		AA3B5117289FD10600C5164C /* AnimalSearchAge.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3B5116289FD10600C5164C /* AnimalSearchAge.swift */; };
 		AA3B5119289FD12700C5164C /* AnimalSearchType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3B5118289FD12700C5164C /* AnimalSearchType.swift */; };
 		AA3B511C289FD27C00C5164C /* AnimalSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3B511B289FD27C00C5164C /* AnimalSearchService.swift */; };
+		AA3B511E289FD9EC00C5164C /* AnimalSearcherMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3B511D289FD9EC00C5164C /* AnimalSearcherMock.swift */; };
 		AA80EA7E289D3BBD000BF8DB /* AnimalsNearYouViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA80EA7D289D3BBD000BF8DB /* AnimalsNearYouViewModel.swift */; };
 		AA80EA81289D8E13000BF8DB /* FetchAnimalsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA80EA80289D8E13000BF8DB /* FetchAnimalsService.swift */; };
 		AA80EA83289D8FAA000BF8DB /* AnimalsFetcherMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA80EA82289D8FAA000BF8DB /* AnimalsFetcherMock.swift */; };
@@ -115,6 +116,7 @@
 		AA3B5116289FD10600C5164C /* AnimalSearchAge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimalSearchAge.swift; sourceTree = "<group>"; };
 		AA3B5118289FD12700C5164C /* AnimalSearchType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimalSearchType.swift; sourceTree = "<group>"; };
 		AA3B511B289FD27C00C5164C /* AnimalSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimalSearchService.swift; sourceTree = "<group>"; };
+		AA3B511D289FD9EC00C5164C /* AnimalSearcherMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimalSearcherMock.swift; sourceTree = "<group>"; };
 		AA80EA7D289D3BBD000BF8DB /* AnimalsNearYouViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimalsNearYouViewModel.swift; sourceTree = "<group>"; };
 		AA80EA80289D8E13000BF8DB /* FetchAnimalsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchAnimalsService.swift; sourceTree = "<group>"; };
 		AA80EA82289D8FAA000BF8DB /* AnimalsFetcherMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimalsFetcherMock.swift; sourceTree = "<group>"; };
@@ -256,6 +258,7 @@
 			isa = PBXGroup;
 			children = (
 				AA3B511B289FD27C00C5164C /* AnimalSearchService.swift */,
+				AA3B511D289FD9EC00C5164C /* AnimalSearcherMock.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -460,8 +463,8 @@
 		AAA22833289686D900081167 /* Search */ = {
 			isa = PBXGroup;
 			children = (
-				AA3B511A289FD27000C5164C /* Services */,
 				AA3B5115289FD0F800C5164C /* Models */,
+				AA3B511A289FD27000C5164C /* Services */,
 				AA3B5112289FD06900C5164C /* ViewModels */,
 				AAA22834289686EA00081167 /* Views */,
 			);
@@ -762,6 +765,7 @@
 				AA34D7E12898FB8F00D37F26 /* AnimalAttributes+CoreData.swift in Sources */,
 				AA34D7DB2898E36B00D37F26 /* Breed+CoreData.swift in Sources */,
 				AACE3E042896F269005ACB10 /* AnimalsContainer.swift in Sources */,
+				AA3B511E289FD9EC00C5164C /* AnimalSearcherMock.swift in Sources */,
 				AACE3DEE2896E56D005ACB10 /* Occupiable.swift in Sources */,
 				AACE3DF42896E8F0005ACB10 /* ApiManager.swift in Sources */,
 				AA34D7EB2898FF1800D37F26 /* PhotoSizes+CoreData.swift in Sources */,

--- a/iOSScalableAppStructure/Search/Services/AnimalSearcherMock.swift
+++ b/iOSScalableAppStructure/Search/Services/AnimalSearcherMock.swift
@@ -1,0 +1,31 @@
+//
+//  AnimalSearcherMock.swift
+//  iOSScalableAppStructure
+//
+//  Created by Geonhee on 2022/08/07.
+//
+
+struct AnimalSearcherMock: AnimalSearcher {
+
+  func searchAnimal(
+    by text: String,
+    age: AnimalSearchAge,
+    type: AnimalSearchType
+  ) async -> [Animal] {
+    var animals = Animal.mock
+
+    if age != .none {
+      animals = animals.filter {
+        $0.age.rawValue.lowercased() == age.rawValue.lowercased()
+      }
+    }
+
+    if type != .none {
+      animals = animals.filter {
+        $0.type.lowercased() == type.rawValue.lowercased()
+      }
+    }
+    return animals.filter { $0.name.contains(text)
+    }
+  }
+}

--- a/iOSScalableAppStructure/Search/Views/SearchView.swift
+++ b/iOSScalableAppStructure/Search/Views/SearchView.swift
@@ -53,6 +53,17 @@ struct SearchView: View {
 
 struct SearchView_Previews: PreviewProvider {
   static var previews: some View {
-    SearchView()
+    SearchView(
+      viewModel: SearchViewModel(
+        animalSearcher: AnimalSearcherMock(),
+        animalStore: AnimalStoreService(
+          context: PersistenceController.preview.container.viewContext
+        )
+      )
+    )
+    .environment(
+      \.managedObjectContext,
+       PersistenceController.preview.container.viewContext
+    )
   }
 }


### PR DESCRIPTION
# Related PRs
- #41 

# Objectives
1. 프리뷰와 유닛 테스트를 위한 `AnimalSearchServiceMock`를 추가합니다.

# Results
프리뷰 촬영 화면입니다. 변경사항은 diff를 참조합니다.
<img src="https://user-images.githubusercontent.com/69730931/183288784-0d4cb80f-d539-4ee7-9784-1891ddb405ca.png" width="320">
