### PR TITLE
검색 결과 없음 화면을 추가합니다.

### DIFF
--- a/iOSScalableAppStructure.xcodeproj/project.pbxproj
+++ b/iOSScalableAppStructure.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		AA3B5119289FD12700C5164C /* AnimalSearchType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3B5118289FD12700C5164C /* AnimalSearchType.swift */; };
 		AA3B511C289FD27C00C5164C /* AnimalSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3B511B289FD27C00C5164C /* AnimalSearchService.swift */; };
 		AA3B511E289FD9EC00C5164C /* AnimalSearcherMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3B511D289FD9EC00C5164C /* AnimalSearcherMock.swift */; };
+		AA3B5120289FDE3500C5164C /* EmptyResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3B511F289FDE3500C5164C /* EmptyResultsView.swift */; };
 		AA80EA7E289D3BBD000BF8DB /* AnimalsNearYouViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA80EA7D289D3BBD000BF8DB /* AnimalsNearYouViewModel.swift */; };
 		AA80EA81289D8E13000BF8DB /* FetchAnimalsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA80EA80289D8E13000BF8DB /* FetchAnimalsService.swift */; };
 		AA80EA83289D8FAA000BF8DB /* AnimalsFetcherMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA80EA82289D8FAA000BF8DB /* AnimalsFetcherMock.swift */; };
@@ -117,6 +118,7 @@
 		AA3B5118289FD12700C5164C /* AnimalSearchType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimalSearchType.swift; sourceTree = "<group>"; };
 		AA3B511B289FD27C00C5164C /* AnimalSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimalSearchService.swift; sourceTree = "<group>"; };
 		AA3B511D289FD9EC00C5164C /* AnimalSearcherMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimalSearcherMock.swift; sourceTree = "<group>"; };
+		AA3B511F289FDE3500C5164C /* EmptyResultsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyResultsView.swift; sourceTree = "<group>"; };
 		AA80EA7D289D3BBD000BF8DB /* AnimalsNearYouViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimalsNearYouViewModel.swift; sourceTree = "<group>"; };
 		AA80EA80289D8E13000BF8DB /* FetchAnimalsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchAnimalsService.swift; sourceTree = "<group>"; };
 		AA80EA82289D8FAA000BF8DB /* AnimalsFetcherMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimalsFetcherMock.swift; sourceTree = "<group>"; };
@@ -475,6 +477,7 @@
 			isa = PBXGroup;
 			children = (
 				AAA228352896870200081167 /* SearchView.swift */,
+				AA3B511F289FDE3500C5164C /* EmptyResultsView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -720,6 +723,7 @@
 				AA80EA7E289D3BBD000BF8DB /* AnimalsNearYouViewModel.swift in Sources */,
 				AA3B5117289FD10600C5164C /* AnimalSearchAge.swift in Sources */,
 				AAA228362896870200081167 /* SearchView.swift in Sources */,
+				AA3B5120289FDE3500C5164C /* EmptyResultsView.swift in Sources */,
 				AA34D7E72898FCC700D37F26 /* Contact+CoreData.swift in Sources */,
 				AA80EA85289E4444000BF8DB /* AnimalStoreService.swift in Sources */,
 				AA3B5108289E778300C5164C /* AnimalAttributesCard.swift in Sources */,

--- a/iOSScalableAppStructure/Search/Views/EmptyResultsView.swift
+++ b/iOSScalableAppStructure/Search/Views/EmptyResultsView.swift
@@ -1,0 +1,33 @@
+//
+//  EmptyResultsView.swift
+//  iOSScalableAppStructure
+//
+//  Created by Geonhee on 2022/08/07.
+//
+
+import SwiftUI
+
+struct EmptyResultsView: View {
+
+  let query: String
+
+  var body: some View {
+    VStack {
+      Image(systemName: "pawprint.circle.fill")
+        .resizable()
+        .frame(width: 64, height: 64)
+        .padding()
+        .foregroundColor(.yellow)
+
+      Text("Sorry, we couldn't find animals for \"\(query)\"")
+        .foregroundColor(.secondary)
+        .multilineTextAlignment(.center)
+    }
+  }
+}
+
+struct EmptyResultsView_Previews: PreviewProvider {
+  static var previews: some View {
+    EmptyResultsView(query: "Kiki")
+  }
+}

--- a/iOSScalableAppStructure/Search/Views/SearchView.swift
+++ b/iOSScalableAppStructure/Search/Views/SearchView.swift
@@ -38,6 +38,11 @@ struct SearchView: View {
   var body: some View {
     NavigationView {
       AnimalListView(animals: filteredAnimals)
+        .overlay {
+          if filteredAnimals.isEmpty && viewModel.searchText.isNotEmpty {
+            EmptyResultsView(query: viewModel.searchText)
+          }
+        }
         .searchable(
           text: $viewModel.searchText,
           placement: .navigationBarDrawer(displayMode: .always)


### PR DESCRIPTION
# Related PRs
- #41 

# Background
기존 검색 기능에는 검색 결과 없음 화면이 제공되지 않아 검색 결과가 없는 경우를 바로 파악하기 어려웠습니다.

# Objectives
1. 검색 결과가 없는 경우 검색 결과 없음 화면을 표시합니다.

# Results
| | iPhone 13 Pro |
|--|--|
| gif | <img src="https://user-images.githubusercontent.com/69730931/183289333-0e9fc233-4203-4d63-9006-552d1f8a9e00.gif" width="320"> |