### PR TITLE
검색 탭의 메인화면에서 동물 종을 선택하여 필터할 수 있는 기능을 추가합니다.

### DIFF
--- a/iOSScalableAppStructure.xcodeproj/project.pbxproj
+++ b/iOSScalableAppStructure.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		AA3B5120289FDE3500C5164C /* EmptyResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3B511F289FDE3500C5164C /* EmptyResultsView.swift */; };
 		AA3B5122289FE1BA00C5164C /* SearchFilterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3B5121289FE1BA00C5164C /* SearchFilterView.swift */; };
 		AA3B5124289FF19C00C5164C /* FilterAnimals.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3B5123289FF19C00C5164C /* FilterAnimals.swift */; };
+		AA3B5126289FFD1A00C5164C /* SuggestionGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3B5125289FFD1A00C5164C /* SuggestionGrid.swift */; };
+		AA3B5128289FFDFC00C5164C /* AnimalTypeSuggestionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3B5127289FFDFC00C5164C /* AnimalTypeSuggestionView.swift */; };
 		AA80EA7E289D3BBD000BF8DB /* AnimalsNearYouViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA80EA7D289D3BBD000BF8DB /* AnimalsNearYouViewModel.swift */; };
 		AA80EA81289D8E13000BF8DB /* FetchAnimalsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA80EA80289D8E13000BF8DB /* FetchAnimalsService.swift */; };
 		AA80EA83289D8FAA000BF8DB /* AnimalsFetcherMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA80EA82289D8FAA000BF8DB /* AnimalsFetcherMock.swift */; };
@@ -123,6 +125,8 @@
 		AA3B511F289FDE3500C5164C /* EmptyResultsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyResultsView.swift; sourceTree = "<group>"; };
 		AA3B5121289FE1BA00C5164C /* SearchFilterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchFilterView.swift; sourceTree = "<group>"; };
 		AA3B5123289FF19C00C5164C /* FilterAnimals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterAnimals.swift; sourceTree = "<group>"; };
+		AA3B5125289FFD1A00C5164C /* SuggestionGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionGrid.swift; sourceTree = "<group>"; };
+		AA3B5127289FFDFC00C5164C /* AnimalTypeSuggestionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimalTypeSuggestionView.swift; sourceTree = "<group>"; };
 		AA80EA7D289D3BBD000BF8DB /* AnimalsNearYouViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimalsNearYouViewModel.swift; sourceTree = "<group>"; };
 		AA80EA80289D8E13000BF8DB /* FetchAnimalsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchAnimalsService.swift; sourceTree = "<group>"; };
 		AA80EA82289D8FAA000BF8DB /* AnimalsFetcherMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimalsFetcherMock.swift; sourceTree = "<group>"; };
@@ -481,9 +485,11 @@
 		AAA22834289686EA00081167 /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				AAA228352896870200081167 /* SearchView.swift */,
 				AA3B511F289FDE3500C5164C /* EmptyResultsView.swift */,
 				AA3B5121289FE1BA00C5164C /* SearchFilterView.swift */,
+				AAA228352896870200081167 /* SearchView.swift */,
+				AA3B5125289FFD1A00C5164C /* SuggestionGrid.swift */,
+				AA3B5127289FFDFC00C5164C /* AnimalTypeSuggestionView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -731,6 +737,7 @@
 				AAA228362896870200081167 /* SearchView.swift in Sources */,
 				AA3B5120289FDE3500C5164C /* EmptyResultsView.swift in Sources */,
 				AA3B5122289FE1BA00C5164C /* SearchFilterView.swift in Sources */,
+				AA3B5126289FFD1A00C5164C /* SuggestionGrid.swift in Sources */,
 				AA34D7E72898FCC700D37F26 /* Contact+CoreData.swift in Sources */,
 				AA80EA85289E4444000BF8DB /* AnimalStoreService.swift in Sources */,
 				AA3B5108289E778300C5164C /* AnimalAttributesCard.swift in Sources */,
@@ -765,6 +772,7 @@
 				AAA2281C2896659300081167 /* ApiConstants.swift in Sources */,
 				AACE3DD92896D5D7005ACB10 /* AnimalAttributes.swift in Sources */,
 				AAA22827289685F000081167 /* Organization.swift in Sources */,
+				AA3B5128289FFDFC00C5164C /* AnimalTypeSuggestionView.swift in Sources */,
 				AACE3DCF2896D510005ACB10 /* Gender.swift in Sources */,
 				AAA2282D2896865C00081167 /* AnimalDetailsView.swift in Sources */,
 				AA34D7E32898FBEA00D37F26 /* AnimalEnvironment+CoreData.swift in Sources */,

--- a/iOSScalableAppStructure/Search/ViewModels/SearchViewModel.swift
+++ b/iOSScalableAppStructure/Search/ViewModels/SearchViewModel.swift
@@ -58,4 +58,9 @@ final class SearchViewModel: ObservableObject {
     ageSelection = .none
     typeSelection = .none
   }
+
+  func selectTypeSuggestion(_ type: AnimalSearchType) {
+    typeSelection = type
+    search()
+  }
 }

--- a/iOSScalableAppStructure/Search/Views/AnimalTypeSuggestionView.swift
+++ b/iOSScalableAppStructure/Search/Views/AnimalTypeSuggestionView.swift
@@ -1,0 +1,53 @@
+//
+//  AnimalTypeSuggestionView.swift
+//  iOSScalableAppStructure
+//
+//  Created by Geonhee on 2022/08/07.
+//
+
+import SwiftUI
+
+struct AnimalTypeSuggestionView: View {
+
+  let suggestion: AnimalSearchType
+  private var gradientColors: [Color] {
+    return [.clear, .black]
+  }
+
+  @ViewBuilder private var gradientOverlay: some View {
+    LinearGradient(
+      colors: gradientColors,
+      startPoint: .top,
+      endPoint: .bottom
+    )
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .opacity(0.3)
+  }
+
+  var body: some View {
+    suggestion.suggestionImage
+      .resizable()
+      .aspectRatio(1, contentMode: .fill)
+      .frame(height: 96)
+      .overlay(gradientOverlay)
+      .overlay(alignment: .bottomLeading) {
+        Text(LocalizedStringKey(suggestion.rawValue.capitalized))
+          .padding(12)
+          .foregroundColor(.white)
+          .font(.headline)
+      }
+      .cornerRadius(16)
+  }
+}
+
+struct AnimalTypeSuggestionView_Previews: PreviewProvider {
+  static var previews: some View {
+    AnimalTypeSuggestionView(suggestion: .cat)
+      .previewLayout(.sizeThatFits)
+
+    AnimalTypeSuggestionView(suggestion: .cat)
+      .previewLayout(.sizeThatFits)
+      .environment(\.locale, Locale(identifier: "es"))
+      .previewDisplayName("Spanish Locale")
+  }
+}

--- a/iOSScalableAppStructure/Search/Views/SearchView.swift
+++ b/iOSScalableAppStructure/Search/Views/SearchView.swift
@@ -60,6 +60,14 @@ struct SearchView: View {
             }
           }
         }
+        .overlay {
+          if filteredAnimals.isEmpty && viewModel.searchText.isEmpty {
+            SuggestionGrid(suggestions: AnimalSearchType.suggestions) { suggestion in
+              viewModel.selectTypeSuggestion(suggestion)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+          }
+        }
         .searchable(
           text: $viewModel.searchText,
           placement: .navigationBarDrawer(displayMode: .always)

--- a/iOSScalableAppStructure/Search/Views/SuggestionGrid.swift
+++ b/iOSScalableAppStructure/Search/Views/SuggestionGrid.swift
@@ -1,0 +1,48 @@
+//
+//  SuggestionGrid.swift
+//  iOSScalableAppStructure
+//
+//  Created by Geonhee on 2022/08/07.
+//
+
+import SwiftUI
+
+struct SuggestionGrid: View {
+
+  @Environment(\.isSearching) var isSearching: Bool
+
+  let suggestions: [AnimalSearchType]
+  var action: (AnimalSearchType) -> Void
+
+  private let columns = [
+    GridItem(.flexible()),
+    GridItem(.flexible())
+  ]
+
+  var body: some View {
+    VStack(alignment: .leading) {
+      Text("Browse by Type")
+        .font(.title2.bold())
+
+      LazyVGrid(columns: columns) {
+        ForEach(AnimalSearchType.suggestions, id: \.self) { suggestion in
+          Button(action: { action(suggestion) }) {
+            AnimalTypeSuggestionView(suggestion: suggestion)
+          }
+          .buttonStyle(.plain)
+        }
+      }
+    }
+    .padding(.horizontal)
+    .opacity(isSearching ? 0 : 1)
+  }
+}
+
+struct SuggestionGrid_Previews: PreviewProvider {
+  static var previews: some View {
+    SuggestionGrid(
+      suggestions: AnimalSearchType.suggestions,
+      action: { _ in }
+    )
+  }
+}


### PR DESCRIPTION
# Related PRs
- #41 
- #44 

# Background
필터가 선택되지 않은 검색탭 기본 화면에는 기본적으로 빈 화면을 표시하고 있어 공간 활용이 되지 않고 있었습니다. 검색 탭에서는 필터 기능을 제공하므로 검색 탭의 메인화면에서 동물 종을 선택하여 필터할 수 있는 기능을 추가합니다.

# Objectives
1. 검색 탭의 메인화면에서 동물 종을 선택하여 필터할 수 있는 기능을 추가합니다. 

# Results
| | iPhone 13 Pro |
|--|--|
| gif | <img src="https://user-images.githubusercontent.com/69730931/183295262-de20e917-62c7-463c-807f-0eabfd2da59e.gif" width="320"> |

