### PR TITLE
`SearchViewModel` 테스트 케이스를 추가합니다.

### DIFF
--- a/iOSScalableAppStructure.xcodeproj/project.pbxproj
+++ b/iOSScalableAppStructure.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		AA3B5124289FF19C00C5164C /* FilterAnimals.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3B5123289FF19C00C5164C /* FilterAnimals.swift */; };
 		AA3B5126289FFD1A00C5164C /* SuggestionGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3B5125289FFD1A00C5164C /* SuggestionGrid.swift */; };
 		AA3B5128289FFDFC00C5164C /* AnimalTypeSuggestionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3B5127289FFDFC00C5164C /* AnimalTypeSuggestionView.swift */; };
+		AA3B512C28A002D300C5164C /* SearchViewModelTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3B512B28A002D300C5164C /* SearchViewModelTestCase.swift */; };
 		AA80EA7E289D3BBD000BF8DB /* AnimalsNearYouViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA80EA7D289D3BBD000BF8DB /* AnimalsNearYouViewModel.swift */; };
 		AA80EA81289D8E13000BF8DB /* FetchAnimalsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA80EA80289D8E13000BF8DB /* FetchAnimalsService.swift */; };
 		AA80EA83289D8FAA000BF8DB /* AnimalsFetcherMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA80EA82289D8FAA000BF8DB /* AnimalsFetcherMock.swift */; };
@@ -127,6 +128,7 @@
 		AA3B5123289FF19C00C5164C /* FilterAnimals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterAnimals.swift; sourceTree = "<group>"; };
 		AA3B5125289FFD1A00C5164C /* SuggestionGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionGrid.swift; sourceTree = "<group>"; };
 		AA3B5127289FFDFC00C5164C /* AnimalTypeSuggestionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimalTypeSuggestionView.swift; sourceTree = "<group>"; };
+		AA3B512B28A002D300C5164C /* SearchViewModelTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModelTestCase.swift; sourceTree = "<group>"; };
 		AA80EA7D289D3BBD000BF8DB /* AnimalsNearYouViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimalsNearYouViewModel.swift; sourceTree = "<group>"; };
 		AA80EA80289D8E13000BF8DB /* FetchAnimalsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchAnimalsService.swift; sourceTree = "<group>"; };
 		AA80EA82289D8FAA000BF8DB /* AnimalsFetcherMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimalsFetcherMock.swift; sourceTree = "<group>"; };
@@ -272,6 +274,14 @@
 				AA3B511D289FD9EC00C5164C /* AnimalSearcherMock.swift */,
 			);
 			path = Services;
+			sourceTree = "<group>";
+		};
+		AA3B512A28A002C300C5164C /* Search */ = {
+			isa = PBXGroup;
+			children = (
+				AA3B512B28A002D300C5164C /* SearchViewModelTestCase.swift */,
+			);
+			path = Search;
 			sourceTree = "<group>";
 		};
 		AA80EA7C289D3BA9000BF8DB /* ViewModels */ = {
@@ -497,9 +507,10 @@
 		AAA2283C2896879400081167 /* iOSScalableAppStructureTests */ = {
 			isa = PBXGroup;
 			children = (
-				AA3B510C289F90F600C5164C /* Helper */,
 				AA3B5109289E810D00C5164C /* AnimalsNearYou */,
+				AA3B512A28A002C300C5164C /* Search */,
 				AACE3E0E2897D5DE005ACB10 /* Core */,
+				AA3B510C289F90F600C5164C /* Helper */,
 			);
 			path = iOSScalableAppStructureTests;
 			sourceTree = "<group>";
@@ -808,6 +819,7 @@
 				AACE3E142897D623005ACB10 /* ApiManagerMock.swift in Sources */,
 				AACF52A12897D964001856C5 /* AnimalsRequestMock.swift in Sources */,
 				AA3B510B289E812A00C5164C /* AnimalsNearYouViewModelTestCase.swift in Sources */,
+				AA3B512C28A002D300C5164C /* SearchViewModelTestCase.swift in Sources */,
 				AA34D7922897F7D800D37F26 /* AccessTokenManagerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/iOSScalableAppStructureTests/Search/SearchViewModelTestCase.swift
+++ b/iOSScalableAppStructureTests/Search/SearchViewModelTestCase.swift
@@ -1,0 +1,96 @@
+//
+//  SearchViewModelTestCase.swift
+//  iOSScalableAppStructureTests
+//
+//  Created by Geonhee on 2022/08/07.
+//
+
+import XCTest
+@testable import iOSScalableAppStructure
+
+final class SearchViewModelTestCase: XCTestCase {
+
+  let testContext = PersistenceController.preview.container.viewContext
+  var sut: SearchViewModel!
+
+  override func setUp() {
+    super.setUp()
+    sut = SearchViewModel(
+      animalSearcher: AnimalSearcherMock(),
+      animalStore: AnimalStoreService(context: testContext)
+    )
+  }
+
+  override func tearDown() {
+    sut = nil
+    super.tearDown()
+  }
+
+  func testShouldFilterIsFalseForEmptyFilters() {
+    XCTAssertTrue(sut.searchText.isEmpty)
+    XCTAssertEqual(sut.ageSelection, .none)
+    XCTAssertEqual(sut.typeSelection, .none)
+    XCTAssertFalse(sut.shouldFilter)
+  }
+
+  func testShouldFilterIsTrueForSearchText() {
+    sut.searchText = "Kiki"
+
+    XCTAssertFalse(sut.searchText.isEmpty)
+    XCTAssertEqual(sut.ageSelection, .none)
+    XCTAssertEqual(sut.typeSelection, .none)
+    XCTAssertTrue(sut.shouldFilter)
+  }
+
+  func testShouldFilterIsTrueForAgeFilter() {
+    sut.ageSelection = .baby
+
+    XCTAssertTrue(sut.searchText.isEmpty)
+    XCTAssertEqual(sut.ageSelection, .baby)
+    XCTAssertEqual(sut.typeSelection, .none)
+    XCTAssertTrue(sut.shouldFilter)
+  }
+
+  func testShouldFilterIsTrueForTypeFilter() {
+    sut.typeSelection = .cat
+
+    XCTAssertTrue(sut.searchText.isEmpty)
+    XCTAssertEqual(sut.ageSelection, .none)
+    XCTAssertEqual(sut.typeSelection, .cat)
+    XCTAssertTrue(sut.shouldFilter)
+  }
+
+  func testClearFiltersSearchTextIsNotEmpty() {
+    sut.typeSelection = .cat
+    sut.ageSelection = .baby
+    sut.searchText = "Kiki"
+
+    sut.clearFilters()
+
+    XCTAssertFalse(sut.searchText.isEmpty)
+    XCTAssertEqual(sut.ageSelection, .none)
+    XCTAssertEqual(sut.typeSelection, .none)
+    XCTAssertTrue(sut.shouldFilter)
+  }
+
+  func testClearFiltersSearchTextIsEmpty() {
+    sut.typeSelection = .cat
+    sut.ageSelection = .baby
+
+    sut.clearFilters()
+
+    XCTAssertTrue(sut.searchText.isEmpty)
+    XCTAssertEqual(sut.ageSelection, .none)
+    XCTAssertEqual(sut.typeSelection, .none)
+    XCTAssertFalse(sut.shouldFilter)
+  }
+
+  func testSelectTypeSuggestion() {
+    sut.selectTypeSuggestion(.cat)
+
+    XCTAssertTrue(sut.searchText.isEmpty)
+    XCTAssertEqual(sut.ageSelection, .none)
+    XCTAssertEqual(sut.typeSelection, .cat)
+    XCTAssertTrue(sut.shouldFilter)
+  }
+}


### PR DESCRIPTION
# Related PRs
- #41 
- #42 
- #44 
- #45 

# Objectives
1. 연관 PR에서 추가한 기능을 검증하는 테스트를 추가합니다.
  1. 검색어와 필터가 적용되지 않았을 때 `shouldFilter`의 상태는 `false`이다.
  2. 검색어가 입력되고 필터가 적용되지 않았을 때 `shouldFilter`의 상태는 `true`이다.
  3. 검색어가 입력되지 않고 나이대 필터가 선택되었을 때 `shouldFilter`의 상태는 `true`이다.
  4. 검색어가 입력되지 않고 종 필터가 선택되었을 때 `shouldFilter`의 상태는 `true`이다.
  5. 검색어를 입력하고 나이대, 종 필터가 선택된 후 `clearFilter()`를 호출하면 필터의 선택 상태는 `.none`이고 `shouldFilter`의 상태는 `true`이다.
  6. 검색어가 입력되지 않은 상태에서 나이대, 종 필터를 선택한 후 `clearFilter()`를 호출하면 필터의 선택 상태는 `.none`이고 `shouldFilter`의 상태는 `false`이다.
  7. `selectTypeSuggestion(_:)`을 호출하면 종 필터가 해당 종으로 선택되고 `shouldFilter`의 상태가 `true`가 된다.


# Results
## Tests
<img width="344" alt="image" src="https://user-images.githubusercontent.com/69730931/183296399-3a2e9d28-554d-409f-83c9-2c422120bb06.png">

## Coverage
<img width="558" alt="image" src="https://user-images.githubusercontent.com/69730931/183296735-bffeb5d7-16b5-4309-94d5-99ecb7a52568.png">